### PR TITLE
P2: Align adapter and architecture docs with MVP reality

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -1,53 +1,53 @@
 # Adapters
 
-Adapters are the key extensibility mechanism in myx.  They allow the system to ingest capabilities from many different formats (imports) and to export the canonical capability model to many different runtimes (exports).  Each adapter is an independent module implementing a simple interface so that new formats can be added without changing the core library.
+In MVP, adapters are built into the Rust CLI/core and are not loaded dynamically.
 
-## Import Adapters
+## MVP Adapter Model
 
-An **import adapter** is responsible for detecting and converting a capability in a source format into the canonical Capability IR.  Each adapter exposes two functions:
+- Target handlers are selected by exact `--target` value.
+- Supported export targets: `openai`, `mcp`, `skill`.
+- Adapters run only after profile/execution validation succeeds.
+- Output is deterministic and written under `.myx/<target>/...`.
+- Semantic loss is reported via structured `loss-report.json`; required mismatches fail build.
 
-- `detect(path: string) → boolean` — returns true if the file or directory at `path` appears to be in the adapter’s supported format.  For example, the SKILL.md importer might check for the existence of a file called `SKILL.md`.
-- `import(path: string) → CapabilityIR` — reads the source file(s) and produces a JavaScript/JSON representation of the capability IR.  If the import fails due to unsupported features or malformed input, the adapter should throw an informative error.
+This model is intentional for v0 and keeps policy/runtime guarantees centralized.
 
-Import adapters should avoid embedding runtime‑specific assumptions.  Their job is to faithfully represent the semantics of the source format in the IR.  Where the source format lacks certain information (e.g. missing permissions), adapters may supply sensible defaults or leave fields blank.
+## Built-In Export Targets
 
-## Export Adapters
+### OpenAI
 
-An **export adapter** takes a Capability IR instance and a destination directory, then writes out the files required for a specific runtime.  Each adapter exposes a single function:
+Writes:
 
-- `export(capability: CapabilityIR, outputPath: string): void` — generates runtime artefacts at `outputPath`.  The format of these artefacts varies by runtime; for example:
-  - **OpenAI tools exporter** writes a `.tools.json` file and a companion `.instructions.md` file containing prompt text.
-  - **SKILL.md exporter** writes a `SKILL.md` file and supporting files such as a commands table.
-  - **MCP exporter** writes a `server.json` or `server.js` config needed to register the capability as an MCP server.
+- `tools.json`
+- `instructions.md`
 
-Export adapters are free to perform additional validation on the IR and may emit warnings if some features are unsupported by the target runtime.  They should not mutate the IR itself.
+### SKILL
 
-## MCP Runtime Wrapper Interop (MVP)
+Writes:
 
-For MVP, generated MCP artifacts use `myx-mcp-wrapper` in strict mode:
+- `SKILL.md`
 
-- `--protocol mcp` uses `Content-Length` framed JSON-RPC messages over stdio.
-- `--protocol simple` preserves the legacy line-delimited JSON loop for local debugging.
+### MCP
 
-Current strict MCP mode is intentionally narrow. It supports the MVP method surface used by generated artifacts:
+Writes:
 
-- `initialize`
-- `tools/list`
-- `tools/call`
-- `ping`
-- `shutdown`
-- `notifications/initialized`
-- `exit`
+- `server.json`
+- `runtime-config.json`
+- `launch.json`
+- `run.sh`
 
-## Implementing Adapters
+Generated MCP launch uses strict protocol mode:
 
-Adapters can be written in any language supported by the myx CLI (initially TypeScript/Node.js).  To be recognised by the CLI, an adapter must register itself in a discovery mechanism (e.g. by exporting certain symbols or by following a naming convention).  The CLI will iterate over available import adapters to determine which one matches a given source directory, and over export adapters to list available output formats.
+- `--protocol mcp` with `Content-Length` framed JSON-RPC over stdio.
 
-## Contributing New Adapters
+## Importers in MVP
 
-If you wish to add support for a new format or runtime, consider the following steps:
+Importer crates may exist and evolve during MVP, but importer completeness is not a release gate for v0.
 
-1. Examine existing adapters for examples of detection and conversion logic.
-2. Write a new module implementing the adapter interface.
-3. Add tests using sample capabilities in the new format.
-4. Update the documentation and open an RFC if the new adapter requires changes to the IR schema.
+## Post-MVP Expansion
+
+The following are deferred to RFC 0005:
+
+- external adapter/plugin loading,
+- adapter discovery/listing commands,
+- broader adapter conformance levels for third-party implementations.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,34 +1,53 @@
 # Architecture
 
-The myx architecture is designed around a central, runtime‑agnostic capability model and a flexible adapter system.  This section describes the main layers and how data flows through them.
+myx MVP is a Rust-core system centered on a canonical capability profile and deterministic build/runtime behavior.
 
-## Layers
+## Runtime Layers (MVP)
 
-myx consists of four conceptual layers:
+1. **Package Sources**
+- Local package path.
+- Project-configured static indexes.
 
-1. **Source Formats** – Capabilities originate in many formats: SKILL.md folders, MCP servers, OpenAI tool schemas, LangChain tool classes, bespoke scripts and so on.  These formats are treated as *inputs*.
-2. **Import Adapters** – For each supported source format, myx implements an adapter that detects and parses the input, producing a canonical *Capability IR* instance.  Adapters are small modules with a uniform interface: `detect()` to determine applicability and `import()` to perform the conversion.
-3. **Capability IR** – The canonical JSON schema that captures all information about a capability: identity, metadata, instructions, tool definitions, permissions, runtime entrypoints and compatibility hints.  Once a capability is represented in this intermediate form, it can be serialised to disk, inspected or versioned.
-4. **Export Adapters** – To use a capability with a particular runtime, an export adapter turns the IR into the appropriate artefact.  Examples include OpenAI tool definition files, SKILL.md bundles, MCP server configuration and custom plugin formats.  The export adapter interface is symmetrical to import: `export()` takes an IR instance and a destination directory and writes the necessary files.
+2. **Resolution + Validation**
+- Resolve package source/version.
+- Load `myx.yaml` and capability profile.
+- Enforce schema/runtime validation before install/build.
+
+3. **Policy + Install**
+- Evaluate permissions against policy mode.
+- Install into local store.
+- Update `myx.lock` atomically on success only.
+
+4. **Built-In Export Engine**
+- Target selection by exact id: `openai`, `mcp`, `skill`.
+- Deterministic artifact emission to `.myx/<target>/...`.
+- Structured loss reporting with hard-fail on required mismatches.
+
+5. **Execution Surface**
+- Global runtime executor enforces declarative `http`/`subprocess` actions.
+- MCP output uses generated wrapper artifacts with strict protocol mode (`--protocol mcp`).
 
 ## Data Flow
 
 ```text
-          Source Format                 Capability IR               Runtime Artefact
-  ────────────────────────────┐ ┌───────────────────────────┐ ┌───────────────────────┐
-  SKILL.md folder            │ │                           │ │ SKILL.md bundle       │
-  MCP server descriptor  ────▶│ Import Adapter ────────────▶│ Export Adapter ───────▶
-  Tool schema JSON           │ │                           │ │ OpenAI tools JSON     │
-  LangChain Python class     │ │                           │ │ MCP server config     │
-  (others)                   │ │                           │ │ (others)              │
-  ────────────────────────────┘ └───────────────────────────┘ └───────────────────────┘
+source (path/static index)
+  -> resolve + validate
+  -> policy decision
+  -> store install + lockfile write
+  -> build target artifacts
+  -> runtime execution via executor/wrapper
 ```
 
-1. A capability in some source format is passed to the corresponding import adapter.
-2. The adapter produces a capability represented in the intermediate JSON schema.
-3. The IR can be inspected, saved, versioned and published.
-4. When needed, an export adapter turns the IR into files consumable by a specific runtime.
+## MVP Boundary
 
-## Why this approach?
+MVP does **not** include:
 
-By isolating the core model (the IR) from the specifics of source and target formats, myx can support new formats with minimal changes.  Adding support for a new runtime means writing one export adapter; adding support for a new existing format means writing one import adapter.  Everything else (versioning, permissions, registry, CLI) stays the same.
+- hosted registry-backed publish/install workflows,
+- external adapter plugins,
+- dynamic adapter discovery.
+
+Those are post-MVP items tracked in RFC 0005.
+
+## Design Rationale
+
+The architecture deliberately favors deterministic behavior and enforcement-grade policy/runtime guarantees over broad first-release target count. Once the core loop is stable, post-MVP expansion reuses the same profile and loss-report contracts.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,25 +1,33 @@
 # Overview
 
-This document provides a high‑level overview of **myx**, a package manager and compatibility layer for agent capabilities.  myx is designed to bridge the gap between existing agent frameworks, such as MCP, SKILL.md, OpenAI tool schemas and bespoke tooling.  Rather than replacing existing standards, myx wraps them in a consistent package format, enabling installation, inspection and re‑export to different runtimes.
+myx is a package manager and compatibility layer for agent capabilities.
+
+The MVP (v0) focuses on one deterministic loop:
+
+1. initialize or obtain a package,
+2. install with explicit policy review,
+3. inspect identity/tools/permissions,
+4. build deterministic target artifacts.
 
 ## Why myx?
 
-The modern agent ecosystem is fragmented.  Capabilities live in many formats — MCP servers, SKILL.md bundles, tool definitions in JSON, framework plugins and one‑off scripts.  Each requires different installation steps and often cannot be easily reused across systems.  This fragmentation slows innovation and makes it hard for developers to share work.
+The agent ecosystem is fragmented: capability definitions and runtime expectations vary by platform. myx provides one canonical capability contract so package authors can describe a tool once and export it to supported runtimes.
 
-myx introduces a canonical **Capability IR** (intermediate representation) that normalises disparate capability descriptions.  Using a set of **import adapters**, myx can ingest existing capability definitions into the IR.  **Export adapters** then emit runtime‑specific artifacts (e.g. OpenAI tool schemas, SKILL.md bundles or MCP server configurations).  This architecture lets developers:
+For MVP, the goal is reliability and enforcement, not maximum ecosystem coverage.
 
-- Package a capability once and reuse it across multiple runtimes.
-- Inspect the permissions and behaviour of a capability before installation.
-- Maintain reproducible installations via lockfiles and checksums.
+## What Ships in MVP
 
-## Components
+- **Rust core + CLI** with `init`, `add`, `inspect`, `build`.
+- **Capability Profile v1** with explicit `tool_class`, `execution`, and permissions.
+- **Static index + local path resolution** (no hosted registry dependency).
+- **Deterministic lockfile/install semantics** with integrity checks.
+- **Built-in export targets**: `openai`, `mcp`, `skill`.
+- **Global runtime executor** for declarative `http` and constrained `subprocess` actions.
 
-The system comprises several key pieces:
+## What Is Deferred
 
-- **Capability IR** — a canonical JSON schema that captures a capability’s identity, instructions, tools, permissions, runtime entrypoints and compatibility hints.
-- **Import Adapters** — code that converts external formats (e.g. SKILL.md folders, MCP server descriptors) into the IR.
-- **Export Adapters** — code that converts the IR into runtime‑specific artifacts (e.g. OpenAI tool definitions).
-- **CLI** — a command line tool for developers to initialise packages, inspect them, install them, build runtime artifacts and publish to a registry.
-- **Registry** — a service that hosts versioned packages, enabling search, download and publishing workflows.
+- Hosted registry and `myx publish` workflows.
+- External adapter plugin model and dynamic adapter discovery.
+- Tier-2 export targets (`vercel`, `claude`, `gemini`).
 
-The rest of the documentation delves into each of these components in more detail.
+Deferred scope is tracked in RFC 0005.

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -1,38 +1,33 @@
 # Package Registry
 
-The myx **registry** is a central repository where capability packages can be published and downloaded.  Similar to package registries such as npm, PyPI or crates.io, the myx registry stores versioned artefacts, metadata and security information.  The registry is not required to use myx locally, but it becomes essential for sharing packages across the community.
+Status: Post-MVP design scope (not shipped in MVP v0).
+
+Current MVP package discovery uses local paths and project-configured static indexes. Hosted registry workflows and `myx publish` are deferred (RFC 0005).
+
+The content below describes the intended future registry direction.
 
 ## Objectives
 
 The registry design focuses on the following goals:
 
-1. **Versioned storage** — Each package version is immutable.  Once published, a version cannot be overwritten; new versions must increment the version number.
-2. **Search and discovery** — Developers should be able to search for capabilities by name, description, semantic tags and declared capabilities (e.g. `read_email`).  The registry may index capability names from the IR to improve discovery.
-3. **Metadata and permissions** — The registry stores the package’s identity, metadata, capability IR and a copy of the package artefact (tarball).  Permissions are surfaced in search results and package pages to aid informed decision making.
-4. **Trust and signatures** — Packages can optionally be signed by their publishers.  The registry may verify signatures and display trust badges.  Additional security scanning (e.g. static analysis for malicious code) is an area for future work.
-5. **Open ecosystem** — The registry API should be open and accessible so that alternative registries, mirrors and private registries can be built.
+1. **Versioned storage** — Each package version is immutable.
+2. **Search and discovery** — Developers can search by name, description, and capabilities.
+3. **Metadata and permissions** — Registry stores package identity, profile metadata, and package artifact.
+4. **Trust and signatures** — Registry can surface signature/provenance signals.
+5. **Open ecosystem** — API should support mirrors and private registries.
 
-## Basic API Endpoints
-
-While the concrete API is subject to change, a minimal registry supports the following operations:
+## Proposed API Endpoints (Post-MVP)
 
 | Endpoint | Description |
 |---------|-------------|
-| `GET /search?q=<query>` | Search for packages by name, description, capabilities or tags.  Returns a list of matching package summaries. |
-| `GET /packages/<name>` | Retrieve metadata about all versions of a package. |
-| `GET /packages/<name>/versions/<version>` | Retrieve metadata about a specific version (including permissions, capabilities, etc.). |
-| `GET /packages/<name>/versions/<version>/download` | Download the package tarball. |
-| `POST /publish` | Publish a new package version.  Requires authentication. |
+| `GET /search?q=<query>` | Search package summaries. |
+| `GET /packages/<name>` | List package versions and metadata. |
+| `GET /packages/<name>/versions/<version>` | Return metadata for one version. |
+| `GET /packages/<name>/versions/<version>/download` | Download package artifact. |
+| `POST /publish` | Publish a new package version (auth required). |
 
-In addition, the registry may implement endpoints for verifying package signatures, listing publishers, rating packages and more.
+## Planned CLI Interaction (Post-MVP)
 
-## Registry and the CLI
+When registry support lands, `myx add` by package name will resolve against configured registries, download metadata/artifacts, validate integrity, and update local lockfile state.
 
-The myx CLI interacts with the registry via simple HTTP requests.  When you run `myx add github@0.1.2`, the CLI will:
-
-1. Resolve `github@0.1.2` against configured registries (by default, the official registry).
-2. Download the metadata and tarball from the registry.
-3. Verify the checksum and signature.
-4. Unpack the package into the local cache and update the lockfile.
-
-Similarly, `myx publish` will send the package tarball and metadata to the registry for storage.  The registry will reject duplicate versions and may require authentication tokens.
+`myx publish` remains deferred until hosted registry and auth contracts are finalized.

--- a/rfcs/0003-adapter-interface.md
+++ b/rfcs/0003-adapter-interface.md
@@ -1,63 +1,118 @@
-# RFC 0003: Adapter Interface
+# RFC 0003: Built-In Adapter Contract (MVP)
 
 *Status: Draft*
 
 ## Summary
 
-This RFC defines the minimal interfaces for import and export adapters in the myx ecosystem.  A clear contract makes it easy for third parties to add support for new source formats and target runtimes without modifying the core library.
+This RFC defines the adapter contract for myx MVP (v0) as implemented by the Rust core.
+
+For MVP:
+
+- Export adapters are built in and selected by exact target id: `openai`, `mcp`, `skill`.
+- Adapter behavior is deterministic and produces explicit loss reports.
+- Dynamic adapter discovery and external plugin loading are out of scope.
+
+This RFC aligns with RFC 0004 (MVP CLI contract) and RFC 0005 (post-MVP expansion).
 
 ## Motivation
 
-The flexibility of myx hinges on its adapter system.  Adapters allow the CLI to ingest capability definitions from diverse formats and output runtime‑specific artefacts.  A lightweight, language‑agnostic interface enables rapid expansion of supported ecosystems.
+Earlier drafts described a generic third-party adapter/plugin interface. That model does not match MVP implementation scope.
 
-## Import Adapter Interface
+MVP needs a tighter contract:
 
-An import adapter is a module that exports two functions:
+1. one deterministic build path,
+2. one enforcement model,
+3. one target set.
 
-```ts
-/**
- * Determines whether the adapter can handle the given path.
- * Should return true if `path` contains a capability in this format.
- */
-export function detect(path: string): Promise<boolean>;
+The goal is to prove install/inspect/build/runtime correctness before opening the adapter surface.
 
-/**
- * Converts the capability at `path` into the canonical IR.
- * Throws an error if the input is malformed or unsupported.
- */
-export function importCapability(path: string): Promise<CapabilityIR>;
-```
+## MVP Scope
 
-Guidelines:
+### In Scope
 
-- `detect()` must not perform heavy operations; it should quickly identify whether the directory contains a recognisable file (e.g. `SKILL.md`, `server.json`).
-- `importCapability()` should read the necessary files and populate all IR fields.  If some fields cannot be inferred, it may leave them blank or apply defaults.
-- If multiple import adapters can handle the same folder, the CLI will apply them in order of specificity (to be defined).
+- Built-in export target handlers for `openai`, `mcp`, `skill`.
+- Deterministic artifact emission under `.myx/<target>/...`.
+- Structured loss-report generation and required-mismatch hard failures.
+- Validation coupling to Capability Profile v1 (`tool_class`, `execution`, permissions).
 
-## Export Adapter Interface
+### Out of Scope (Deferred to RFC 0005)
 
-An export adapter exports a single function:
+- External adapter plugins.
+- Runtime adapter discovery/registration commands (including `myx list-adapters`).
+- Adapter interfaces intended for arbitrary third-party runtime loading.
 
-```ts
-/**
- * Writes runtime artefacts for the given capability IR into `outputPath`.
- * May throw if the IR contains unsupported features.
- */
-export function exportCapability(capability: CapabilityIR, outputPath: string): Promise<void>;
-```
+## Adapter Contract (Normative)
 
-Guidelines:
+### Inputs
 
-- The adapter should validate the IR against any requirements of the target runtime (e.g. parameter types supported by OpenAI tools).
-- It should write files into the `outputPath` directory, creating subdirectories as needed (e.g. `openai`, `skill`, etc.).
-- It must not modify the passed IR.
+Each built-in export receives:
 
-## Adapter Discovery
+1. a fully validated package profile,
+2. a destination output directory,
+3. target-specific context (for example package base directory for MCP runtime config).
 
-To simplify usage, adapters may be discovered via a naming convention (e.g. files in a particular folder ending with `-importer.ts` or `-exporter.ts`) or via explicit registration in a configuration file.  The CLI should provide commands such as `myx list-adapters` to list available import and export adapters.
+Validation must complete before adapter execution begins.
 
-## Open Questions
+### Outputs
 
-- Should adapters support streaming conversion for large packages?
-- How should adapters handle partial or experimental support for features?  Should they emit warnings or errors?
-- What is the best way to support adapters in multiple languages (e.g. Python)?
+Each export returns:
+
+1. runtime artifacts written to output directory,
+2. zero or more structured issues describing lossy or incompatible semantics.
+
+Issue fields:
+
+- `level`
+- `category`
+- `tool` (optional)
+- `message`
+- `required_mismatch` (boolean)
+
+If any issue has `required_mismatch = true`, build must fail (RFC 0004 exit code `7`) after writing `loss-report.json`.
+
+## Built-In Target Requirements
+
+### `openai`
+
+Must emit deterministic:
+
+- `tools.json`
+- `instructions.md`
+
+If a tool requires subprocess execution semantics that cannot be preserved, emit required mismatch.
+
+### `skill`
+
+Must emit deterministic:
+
+- `SKILL.md`
+
+If tool semantics are not runnable/preservable in documentation-only output, emit required mismatch.
+
+### `mcp`
+
+Must emit deterministic:
+
+- `server.json`
+- `runtime-config.json`
+- `launch.json`
+- `run.sh`
+
+Generated launch behavior must use strict MCP framing mode (`--protocol mcp`) and route execution through the global runtime executor.
+
+## Import Adapters in MVP
+
+Importers are non-blocking for MVP ship. Existing importer crates may evolve independently, but importer completeness is not a release gate for v0.
+
+## Determinism and Safety Requirements
+
+All built-in adapters must:
+
+1. avoid mutating source package files,
+2. produce byte-stable output for unchanged inputs,
+3. surface semantic loss explicitly (no silent drops),
+4. preserve policy/runtime enforcement boundaries (no direct shell shortcuts outside executor rules).
+
+## Post-MVP Extension Boundary
+
+External adapter/plugin design is intentionally deferred. Any future plugin architecture must preserve the same loss-report and policy guarantees defined in MVP RFCs.


### PR DESCRIPTION
## Summary
- rewrite RFC 0003 to match the shipped MVP adapter model (built-in Rust targets, deterministic exports, explicit loss reporting)
- update high-level docs so MVP boundaries are clear (overview, architecture, adapters)
- mark registry docs as post-MVP design scope and remove MVP implications around publish/hosted registry workflows

## Why
Issue #9 identified conflicting pre-MVP plugin/discovery language and implied shipped registry workflows that do not match current MVP reality.

## Validation
- bash scripts/check-mvp-contract.sh
- manual consistency pass against RFC 0004 and RFC 0005

Closes #9
