### PR TITLE
Rename MCP wrapper to runtime runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ cargo run -p myx-cli -- --help
 # build MCP artifacts for a package
 cargo run -p myx-cli -- build --target mcp
 
-# validate and run generated MCP runtime config
-cargo run -p myx-runtime-executor --bin myx-mcp-wrapper -- --config .myx/mcp/runtime-config.json --healthcheck
+# run generated MCP server artifact (runtime bridge is internal)
+./.myx/mcp/run.sh --healthcheck
 ```
 
 ## Contributing

--- a/crates/myx-cli/src/commands/build.rs
+++ b/crates/myx-cli/src/commands/build.rs
@@ -75,6 +75,9 @@ pub fn command_build(
         );
     } else {
         println!("built target '{}' to {}", target, out_dir.display());
+        if target == "mcp" {
+            println!("run: {}", out_dir.join("run.sh").display());
+        }
         if !loss.is_empty() {
             println!(
                 "loss report: {}",

--- a/crates/myx-cli/src/export.rs
+++ b/crates/myx-cli/src/export.rs
@@ -207,8 +207,8 @@ pub fn build_mcp(
     write_json(&out_dir.join("runtime-config.json"), &runtime_config)?;
 
     let launch = json!({
-        "command": "myx-mcp-wrapper",
-        "args": ["--config", "runtime-config.json", "--protocol", "mcp"],
+        "command": "./run.sh",
+        "args": [],
         "cwd": ".",
         "startup": "deterministic"
     });
@@ -217,7 +217,16 @@ pub fn build_mcp(
     let run_script = r#"#!/usr/bin/env sh
 set -eu
 SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
-exec "${MYX_MCP_WRAPPER_BIN:-myx-mcp-wrapper}" --config "$SCRIPT_DIR/runtime-config.json" --protocol mcp
+RUNNER_BIN="${MYX_MCP_RUNNER_BIN:-myx-mcp-runner}"
+if command -v "$RUNNER_BIN" >/dev/null 2>&1; then
+  exec "$RUNNER_BIN" --config "$SCRIPT_DIR/runtime-config.json" --protocol mcp "$@"
+fi
+DEV_RUNNER="$SCRIPT_DIR/../../target/debug/myx-mcp-runner"
+if [ -x "$DEV_RUNNER" ]; then
+  exec "$DEV_RUNNER" --config "$SCRIPT_DIR/runtime-config.json" --protocol mcp "$@"
+fi
+echo "myx MCP runtime bridge not found; install myx or set MYX_MCP_RUNNER_BIN" >&2
+exit 127
 "#;
     let run_path = out_dir.join("run.sh");
     std::fs::write(&run_path, run_script)?;
@@ -335,7 +344,7 @@ mod tests {
     }
 
     #[test]
-    fn build_mcp_writes_wrapper_assets() {
+    fn build_mcp_writes_runtime_assets() {
         let profile = sample_profile(vec![http_tool("get_repo")]);
         let tmp = TempDir::new().expect("tempdir");
         build_mcp(tmp.path(), tmp.path(), &profile).expect("build mcp");
@@ -356,10 +365,8 @@ mod tests {
             &std::fs::read_to_string(tmp.path().join("launch.json")).expect("read launch"),
         )
         .expect("parse launch");
-        assert_eq!(
-            launch["args"],
-            serde_json::json!(["--config", "runtime-config.json", "--protocol", "mcp"])
-        );
+        assert_eq!(launch["command"], "./run.sh");
+        assert_eq!(launch["args"], serde_json::json!([]));
     }
 
     #[test]

--- a/crates/myx-runtime-executor/Cargo.toml
+++ b/crates/myx-runtime-executor/Cargo.toml
@@ -6,8 +6,8 @@ license.workspace = true
 repository.workspace = true
 
 [[bin]]
-name = "myx-mcp-wrapper"
-path = "src/bin/myx-mcp-wrapper.rs"
+name = "myx-mcp-runner"
+path = "src/bin/myx-mcp-runner.rs"
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/myx-runtime-executor/src/bin/myx-mcp-runner.rs
+++ b/crates/myx-runtime-executor/src/bin/myx-mcp-runner.rs
@@ -16,8 +16,8 @@ enum ProtocolMode {
 }
 
 #[derive(Debug, Parser)]
-#[command(name = "myx-mcp-wrapper")]
-#[command(about = "myx deterministic MCP wrapper runtime")]
+#[command(name = "myx-mcp-runner")]
+#[command(about = "myx deterministic MCP runtime bridge")]
 struct Cli {
     #[arg(long, value_name = "PATH")]
     config: PathBuf,

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -36,6 +36,8 @@ Writes:
 - `launch.json`
 - `run.sh`
 
+`run.sh` is the user-facing entrypoint. The underlying runtime bridge binary is an internal detail.
+
 Generated MCP launch uses strict protocol mode:
 
 - `--protocol mcp` with `Content-Length` framed JSON-RPC over stdio.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,7 +25,7 @@ myx MVP is a Rust-core system centered on a canonical capability profile and det
 
 5. **Execution Surface**
 - Global runtime executor enforces declarative `http`/`subprocess` actions.
-- MCP output uses generated wrapper artifacts with strict protocol mode (`--protocol mcp`).
+- MCP output uses generated launch artifacts (`run.sh` entrypoint) with strict protocol mode (`--protocol mcp`).
 
 ## Data Flow
 
@@ -35,7 +35,7 @@ source (path/static index)
   -> policy decision
   -> store install + lockfile write
   -> build target artifacts
-  -> runtime execution via executor/wrapper
+  -> runtime execution via executor/bridge
 ```
 
 ## MVP Boundary

--- a/docs/audits/2026-03-mvp-hardening-audit.md
+++ b/docs/audits/2026-03-mvp-hardening-audit.md
@@ -14,7 +14,7 @@ Track and execute hardening tasks to ensure:
 
 1. `P0` Verify index digest over full package payload (not profile-only).
 2. `P0` Make store install non-destructive and atomic.
-3. `P1` Fix MCP wrapper cwd semantics for subprocess tools.
+3. `P1` Fix MCP runtime bridge cwd semantics for subprocess tools.
 4. `P1` Align loss-report schema with emitted payload.
 5. `P1` Strengthen capability profile schema to match runtime validation.
 6. `P2` Add strict MCP protocol compatibility mode.


### PR DESCRIPTION
## Summary
- rename MCP runtime binary from `myx-mcp-wrapper` to `myx-mcp-runner`
- replace user-facing "wrapper" wording with "runtime bridge"/"runner"
- keep generated MCP entrypoint as `run.sh` so users do not need to know internal binary details

## Behavioral updates
- generated `.myx/mcp/run.sh` now resolves `myx-mcp-runner` (or `MYX_MCP_RUNNER_BIN`)
- local dev fallback in `run.sh` points to `target/debug/myx-mcp-runner`
- `myx build --target mcp` continues printing the `run.sh` command for execution

## Validation
- cargo test -p myx-cli
- cargo test -p myx-runtime-executor
- cargo run -p myx-cli -- build --target mcp --package examples/github-capability
- ./.myx/mcp/run.sh --healthcheck

