### PR TITLE
MVP: add --json support to myx init

### DIFF
--- a/crates/myx-cli/src/cli.rs
+++ b/crates/myx-cli/src/cli.rs
@@ -17,6 +17,8 @@ pub enum Commands {
         path: Option<PathBuf>,
         #[arg(long, default_value_t = false)]
         force: bool,
+        #[arg(long, default_value_t = false)]
+        json: bool,
     },
     Add {
         package: String,

--- a/crates/myx-cli/src/commands/init.rs
+++ b/crates/myx-cli/src/commands/init.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use myx_core::{CapabilityProfile, PackageManifest, ToolClass, ToolDefinition, ToolExecution};
 use serde_json::json;
 
-pub fn command_init(path: Option<PathBuf>, force: bool) -> Result<()> {
+pub fn command_init(path: Option<PathBuf>, force: bool, json_output: bool) -> Result<()> {
     let target = path.unwrap_or_else(|| PathBuf::from("."));
     std::fs::create_dir_all(&target)?;
 
@@ -99,6 +99,18 @@ pub fn command_init(path: Option<PathBuf>, force: bool) -> Result<()> {
 
     std::fs::write(&manifest_path, serde_yaml::to_string(&manifest)?)?;
     std::fs::write(&profile_path, serde_json::to_vec_pretty(&profile)?)?;
-    println!("initialized package scaffold in {}", target.display());
+
+    if json_output {
+        let out = json!({
+            "command": "init",
+            "ok": true,
+            "path": target.display().to_string(),
+            "manifest_path": manifest_path.display().to_string(),
+            "profile_path": profile_path.display().to_string()
+        });
+        println!("{}", serde_json::to_string_pretty(&out)?);
+    } else {
+        println!("initialized package scaffold in {}", target.display());
+    }
     Ok(())
 }

--- a/crates/myx-cli/src/main.rs
+++ b/crates/myx-cli/src/main.rs
@@ -14,8 +14,8 @@ use crate::util::chrono_like_timestamp;
 
 fn run(cli: Cli) -> Result<(), CliExit> {
     match cli.command {
-        Commands::Init { path, force } => {
-            commands::command_init(path, force).map_err(|e| fail(3, e))
+        Commands::Init { path, force, json } => {
+            commands::command_init(path, force, json).map_err(|e| fail(3, e))
         }
         Commands::Add {
             package,

--- a/crates/myx-cli/tests/init_json.rs
+++ b/crates/myx-cli/tests/init_json.rs
@@ -1,0 +1,62 @@
+use std::path::Path;
+use std::process::Command;
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn run_myx(args: &[&str], cwd: &Path) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_myx"))
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .expect("run myx")
+}
+
+#[test]
+fn init_json_outputs_machine_readable_payload() {
+    let tmp = TempDir::new().expect("tempdir");
+    let pkg_dir = tmp.path().join("sample-capability");
+
+    let output = run_myx(
+        &["init", pkg_dir.to_str().expect("utf8 path"), "--json"],
+        tmp.path(),
+    );
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("utf8 stdout");
+    let payload: Value = serde_json::from_str(&stdout).expect("json output");
+    assert_eq!(payload["command"], "init");
+    assert_eq!(payload["ok"], true);
+    assert_eq!(
+        payload["manifest_path"],
+        pkg_dir.join("myx.yaml").display().to_string()
+    );
+    assert_eq!(
+        payload["profile_path"],
+        pkg_dir.join("capability.json").display().to_string()
+    );
+
+    assert!(pkg_dir.join("myx.yaml").exists());
+    assert!(pkg_dir.join("capability.json").exists());
+}
+
+#[test]
+fn init_default_output_stays_human_readable() {
+    let tmp = TempDir::new().expect("tempdir");
+    let pkg_dir = tmp.path().join("human-output");
+
+    let output = run_myx(&["init", pkg_dir.to_str().expect("utf8 path")], tmp.path());
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("utf8 stdout");
+    assert!(stdout.contains("initialized package scaffold in"));
+    assert!(serde_json::from_str::<Value>(&stdout).is_err());
+}


### PR DESCRIPTION
## Summary
- add `--json` support to `myx init`
- keep existing human-readable output as default
- add integration tests validating JSON payload shape and default non-JSON behavior

## Why
RFC 0004 requires JSON output support across commands. `init` was the only command missing this.

## Validation
- cargo fmt --all
- cargo test -p myx-cli
- bash scripts/check-mvp-contract.sh

Closes #16
