### PR TITLE
MVP: enforce filesystem bounds in runtime executor

### DIFF
--- a/crates/myx-core/src/lib.rs
+++ b/crates/myx-core/src/lib.rs
@@ -419,6 +419,13 @@ pub fn validate_package(manifest: &PackageManifest, profile: &CapabilityProfile)
                         "subprocess tools require permissions.subprocess.max_timeout_ms"
                     ));
                 }
+                if profile.permissions.filesystem.read.is_empty()
+                    && profile.permissions.filesystem.write.is_empty()
+                {
+                    return Err(anyhow!(
+                        "subprocess tools require filesystem read or write bounds"
+                    ));
+                }
             }
         }
     }
@@ -434,4 +441,83 @@ pub fn assert_supported_target(target: &str) -> Result<()> {
         target,
         SUPPORTED_TARGETS.join(", ")
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn subprocess_manifest() -> PackageManifest {
+        PackageManifest {
+            name: "sample".to_string(),
+            version: "1.0.0".to_string(),
+            description: String::new(),
+            publisher: String::new(),
+            license: String::new(),
+            ir: Some("./capability.json".to_string()),
+        }
+    }
+
+    fn subprocess_profile() -> CapabilityProfile {
+        CapabilityProfile {
+            schema_version: PROFILE_SCHEMA_VERSION.to_string(),
+            identity: Identity {
+                name: "sample".to_string(),
+                version: "1.0.0".to_string(),
+                publisher: String::new(),
+                license: String::new(),
+            },
+            metadata: Metadata::default(),
+            capabilities: vec!["test".to_string()],
+            instructions: Instructions {
+                system: "system".to_string(),
+                usage: "usage".to_string(),
+            },
+            tools: vec![ToolDefinition {
+                name: "run".to_string(),
+                description: "run local command".to_string(),
+                parameters: json!({"type":"object"}),
+                tool_class: ToolClass::LocalProcess,
+                execution: ToolExecution::Subprocess {
+                    command: "echo".to_string(),
+                    args: vec!["hello".to_string()],
+                    cwd: Some(".".to_string()),
+                    env_passthrough: vec![],
+                    timeout_ms: Some(1000),
+                },
+            }],
+            permissions: Permissions {
+                network: vec![],
+                secrets: vec![],
+                filesystem: FilesystemPermissions::default(),
+                subprocess: SubprocessPermissions {
+                    allowed_commands: vec!["echo".to_string()],
+                    allowed_cwds: vec![".".to_string()],
+                    allowed_env: vec![],
+                    max_timeout_ms: Some(2000),
+                },
+            },
+            compatibility: Compatibility {
+                runtimes: vec!["mcp".to_string()],
+                platforms: vec!["darwin".to_string()],
+            },
+        }
+    }
+
+    #[test]
+    fn subprocess_tools_require_filesystem_bounds() {
+        let manifest = subprocess_manifest();
+        let profile = subprocess_profile();
+        let err = validate_package(&manifest, &profile).expect_err("expected fs bounds error");
+        assert!(err.to_string().contains("filesystem read or write bounds"));
+    }
+
+    #[test]
+    fn subprocess_tools_accept_filesystem_bounds() {
+        let manifest = subprocess_manifest();
+        let mut profile = subprocess_profile();
+        profile.permissions.filesystem.read = vec![".".to_string()];
+        validate_package(&manifest, &profile).expect("profile should validate");
+    }
 }

--- a/crates/myx-runtime-executor/src/lib.rs
+++ b/crates/myx-runtime-executor/src/lib.rs
@@ -184,6 +184,13 @@ fn validate_tool_permissions(
                     resolved_cwd.display()
                 );
             }
+            if !cwd_within_filesystem_bounds(base_dir, &resolved_cwd, permissions) {
+                anyhow::bail!(
+                    "tool '{}' cwd '{}' is outside permissions.filesystem bounds",
+                    tool.name,
+                    resolved_cwd.display()
+                );
+            }
 
             for env_key in env_passthrough {
                 if !contains_or_wildcard(&permissions.subprocess.allowed_env, env_key) {
@@ -353,6 +360,12 @@ fn execute_subprocess(
     ) {
         anyhow::bail!(
             "subprocess cwd '{}' not allowed by permissions.subprocess.allowed_cwds",
+            resolved_cwd.display()
+        );
+    }
+    if !cwd_within_filesystem_bounds(base_dir, &resolved_cwd, permissions) {
+        anyhow::bail!(
+            "subprocess cwd '{}' is outside permissions.filesystem bounds",
             resolved_cwd.display()
         );
     }
@@ -540,6 +553,28 @@ fn cwd_is_allowed(base_dir: &Path, requested: &Path, allowed_cwds: &[String]) ->
     })
 }
 
+fn cwd_within_filesystem_bounds(
+    base_dir: &Path,
+    requested: &Path,
+    permissions: &Permissions,
+) -> bool {
+    path_is_within_allowlist(base_dir, requested, &permissions.filesystem.read)
+        || path_is_within_allowlist(base_dir, requested, &permissions.filesystem.write)
+}
+
+fn path_is_within_allowlist(base_dir: &Path, requested: &Path, allowlist: &[String]) -> bool {
+    if allowlist.iter().any(|a| a == "*") {
+        return true;
+    }
+
+    let requested_norm = normalize_path(requested);
+    allowlist.iter().any(|entry| {
+        let allowed_path = resolve_cwd(base_dir, Some(entry));
+        let allowed_norm = normalize_path(&allowed_path);
+        requested_norm == allowed_norm || requested_norm.starts_with(&allowed_norm)
+    })
+}
+
 fn normalize_path(path: &Path) -> PathBuf {
     std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
@@ -557,7 +592,10 @@ mod tests {
         Permissions {
             network: vec!["127.0.0.1".to_string()],
             secrets: Vec::new(),
-            filesystem: FilesystemPermissions::default(),
+            filesystem: FilesystemPermissions {
+                read: vec![".".to_string()],
+                write: vec![".".to_string()],
+            },
             subprocess: SubprocessPermissions {
                 allowed_commands: vec!["echo".to_string()],
                 allowed_cwds: vec![".".to_string()],
@@ -612,6 +650,23 @@ mod tests {
         )
         .expect_err("expected allowlist failure");
         assert!(err.to_string().contains("allowed_commands"));
+    }
+
+    #[test]
+    fn subprocess_rejects_cwd_outside_filesystem_bounds() {
+        let tmp = TempDir::new().expect("tempdir");
+        let mut permissions = test_permissions();
+        permissions.filesystem.read = vec!["./allowed".to_string()];
+        permissions.filesystem.write = vec!["./allowed".to_string()];
+
+        let err = execute_tool(
+            &subprocess_tool(),
+            &permissions,
+            tmp.path(),
+            &serde_json::json!({"message":"hello"}),
+        )
+        .expect_err("expected filesystem bounds failure");
+        assert!(err.to_string().contains("filesystem bounds"));
     }
 
     #[test]

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -48,6 +48,7 @@ MVP requires strict execution constraints:
 - exact command allowlist
 - explicit cwd allowlist
 - explicit env passthrough allowlist
+- cwd must fall within declared filesystem read/write bounds
 - required timeout
 - direct exec only (no shell invocation, no shell expansion)
 

--- a/rfcs/0004-cli-contract.md
+++ b/rfcs/0004-cli-contract.md
@@ -150,8 +150,11 @@ For `execution.kind = subprocess`, executor enforcement must include:
 - Exact command allowlist.
 - Explicit cwd rules.
 - Explicit env passthrough allowlist.
+- Filesystem bounds enforcement using declared read/write paths.
 - Required timeout.
 - Direct exec only (no shell invocation, no shell expansion).
+
+For MVP package validation, subprocess-capable packages must declare at least one filesystem bound (`permissions.filesystem.read` or `permissions.filesystem.write`).
 
 ## Configuration Resolution
 


### PR DESCRIPTION
## Summary
- enforce filesystem bounds for subprocess execution in runtime validation/execution paths
- require subprocess-capable packages to declare at least one filesystem bound during package validation
- add coverage for allow/deny filesystem bound behavior in core and runtime tests
- document the enforcement in MVP RFC + permissions docs

## Why
Issue #17: subprocess runtime behavior needed explicit filesystem bound enforcement to match MVP security contract.

## Validation
- cargo fmt --all
- cargo test -p myx-core
- cargo test -p myx-runtime-executor
- bash scripts/check-mvp-contract.sh

Closes #17
