### PR TITLE
MVP: add deterministic export and MCP e2e harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,10 @@ jobs:
         run: cargo clippy --workspace --all-targets -- -D warnings
       - name: Tests
         run: cargo test --workspace
+      - name: Warm-cache add benchmark (non-gate)
+        run: ./scripts/benchmark-warm-cache-add.sh --out ./warm-cache-add.json
+      - name: Upload warm-cache benchmark artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: warm-cache-add
+          path: ./warm-cache-add.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,12 @@ cargo test --workspace
 
 If your change touches schemas or adapters, include fixture/golden tests that prove deterministic output.
 
+Warm-cache benchmark tracking (non-gate):
+
+```bash
+./scripts/benchmark-warm-cache-add.sh --out ./warm-cache-add.json
+```
+
 ## Specs and RFC Expectations
 
 - Public behavior contracts belong in RFCs.

--- a/crates/myx-cli/src/export.rs
+++ b/crates/myx-cli/src/export.rs
@@ -245,7 +245,16 @@ exit 127
 mod tests {
     use super::*;
     use myx_core::{ToolClass, ToolDefinition};
+    use std::path::Path;
     use tempfile::TempDir;
+
+    fn assert_same_files(a: &Path, b: &Path, files: &[&str]) {
+        for file in files {
+            let left = std::fs::read(a.join(file)).expect("read left output");
+            let right = std::fs::read(b.join(file)).expect("read right output");
+            assert_eq!(left, right, "mismatch for output file '{}'", file);
+        }
+    }
 
     fn sample_profile(tools: Vec<ToolDefinition>) -> CapabilityProfile {
         CapabilityProfile {
@@ -378,5 +387,47 @@ mod tests {
         let report = loss_report_json("openai", &issues);
         assert_eq!(report["summary"]["total"], 2);
         assert_eq!(report["summary"]["required_mismatches"], 2);
+    }
+
+    #[test]
+    fn tier1_exports_are_deterministic() {
+        let profile = sample_profile(vec![http_tool("z_tool"), http_tool("a_tool")]);
+        let tmp = TempDir::new().expect("tempdir");
+
+        let openai_a = tmp.path().join("openai-a");
+        let openai_b = tmp.path().join("openai-b");
+        std::fs::create_dir_all(&openai_a).expect("openai-a dir");
+        std::fs::create_dir_all(&openai_b).expect("openai-b dir");
+        let issues_a = build_openai(&openai_a, &profile).expect("build openai a");
+        let issues_b = build_openai(&openai_b, &profile).expect("build openai b");
+        assert_eq!(issues_a.len(), issues_b.len());
+        assert_same_files(&openai_a, &openai_b, &["tools.json", "instructions.md"]);
+
+        let skill_a = tmp.path().join("skill-a");
+        let skill_b = tmp.path().join("skill-b");
+        std::fs::create_dir_all(&skill_a).expect("skill-a dir");
+        std::fs::create_dir_all(&skill_b).expect("skill-b dir");
+        let issues_a = build_skill(&skill_a, &profile).expect("build skill a");
+        let issues_b = build_skill(&skill_b, &profile).expect("build skill b");
+        assert_eq!(issues_a.len(), issues_b.len());
+        assert_same_files(&skill_a, &skill_b, &["SKILL.md"]);
+
+        let mcp_a = tmp.path().join("mcp-a");
+        let mcp_b = tmp.path().join("mcp-b");
+        std::fs::create_dir_all(&mcp_a).expect("mcp-a dir");
+        std::fs::create_dir_all(&mcp_b).expect("mcp-b dir");
+        let issues_a = build_mcp(&mcp_a, tmp.path(), &profile).expect("build mcp a");
+        let issues_b = build_mcp(&mcp_b, tmp.path(), &profile).expect("build mcp b");
+        assert_eq!(issues_a.len(), issues_b.len());
+        assert_same_files(
+            &mcp_a,
+            &mcp_b,
+            &[
+                "server.json",
+                "runtime-config.json",
+                "launch.json",
+                "run.sh",
+            ],
+        );
     }
 }

--- a/crates/myx-runtime-executor/tests/mcp_runner_e2e.rs
+++ b/crates/myx-runtime-executor/tests/mcp_runner_e2e.rs
@@ -1,0 +1,172 @@
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::{json, Value};
+use std::net::TcpListener;
+use tempfile::TempDir;
+
+fn write_runtime_config(dir: &Path, port: u16) -> PathBuf {
+    let config_path = dir.join("runtime-config.json");
+    let config = json!({
+        "schema_version": 1,
+        "identity": {
+            "name": "e2e",
+            "version": "0.1.0",
+            "publisher": "myx",
+            "license": "Apache-2.0"
+        },
+        "base_dir": ".",
+        "permissions": {
+            "network": ["127.0.0.1"],
+            "secrets": [],
+            "filesystem": {
+                "read": ["."],
+                "write": ["."]
+            },
+            "subprocess": {
+                "allowed_commands": ["echo"],
+                "allowed_cwds": ["."],
+                "allowed_env": ["HOME"],
+                "max_timeout_ms": 2000
+            }
+        },
+        "tools": [
+            {
+                "name": "http_ping",
+                "description": "http tool for e2e",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string"}
+                    },
+                    "required": ["query"]
+                },
+                "tool_class": "http_api",
+                "execution": {
+                    "kind": "http",
+                    "method": "GET",
+                    "url": format!("http://127.0.0.1:{port}/status?q={{{{query}}}}"),
+                    "headers": {},
+                    "timeout_ms": 1000
+                }
+            },
+            {
+                "name": "echo_local",
+                "description": "subprocess tool for e2e",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "message": {"type": "string"}
+                    },
+                    "required": ["message"]
+                },
+                "tool_class": "local_process",
+                "execution": {
+                    "kind": "subprocess",
+                    "command": "echo",
+                    "args": ["{{message}}"],
+                    "cwd": ".",
+                    "env_passthrough": ["HOME"],
+                    "timeout_ms": 1000
+                }
+            }
+        ]
+    });
+    std::fs::write(
+        &config_path,
+        serde_json::to_vec_pretty(&config).expect("serialize config"),
+    )
+    .expect("write runtime config");
+    config_path
+}
+
+fn run_runner(dir: &Path, config: &Path, args: &[&str]) -> std::process::Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_myx-mcp-runner"));
+    command.current_dir(dir).arg("--config").arg(config);
+    for arg in args {
+        command.arg(arg);
+    }
+    command.output().expect("run mcp runner")
+}
+
+#[test]
+fn mcp_runner_healthcheck_and_tool_invokes_work_e2e() {
+    let tmp = TempDir::new().expect("tempdir");
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind local http listener");
+    let addr = listener.local_addr().expect("listener addr");
+
+    let server = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept connection");
+        let mut request = [0u8; 2048];
+        let _ = stream.read(&mut request);
+        let body = "ok-http";
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: text/plain\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        stream
+            .write_all(response.as_bytes())
+            .expect("write response");
+    });
+
+    let config_path = write_runtime_config(tmp.path(), addr.port());
+
+    let health = run_runner(tmp.path(), &config_path, &["--healthcheck"]);
+    assert!(
+        health.status.success(),
+        "healthcheck stderr: {}",
+        String::from_utf8_lossy(&health.stderr)
+    );
+    let health_payload: Value =
+        serde_json::from_slice(&health.stdout).expect("parse healthcheck json");
+    assert_eq!(health_payload["ok"], true);
+
+    let http = run_runner(
+        tmp.path(),
+        &config_path,
+        &[
+            "--invoke",
+            "http_ping",
+            "--args-json",
+            "{\"query\":\"repo\"}",
+        ],
+    );
+    assert!(
+        http.status.success(),
+        "http invoke stderr: {}",
+        String::from_utf8_lossy(&http.stderr)
+    );
+    let http_payload: Value = serde_json::from_slice(&http.stdout).expect("parse http json");
+    assert_eq!(http_payload["ok"], true);
+    assert_eq!(http_payload["result"]["kind"], "http");
+    assert_eq!(http_payload["result"]["status_code"], 200);
+    assert_eq!(http_payload["result"]["body"], "ok-http");
+
+    server.join().expect("join http server");
+
+    let subprocess = run_runner(
+        tmp.path(),
+        &config_path,
+        &[
+            "--invoke",
+            "echo_local",
+            "--args-json",
+            "{\"message\":\"hello\"}",
+        ],
+    );
+    assert!(
+        subprocess.status.success(),
+        "subprocess invoke stderr: {}",
+        String::from_utf8_lossy(&subprocess.stderr)
+    );
+    let subprocess_payload: Value =
+        serde_json::from_slice(&subprocess.stdout).expect("parse subprocess json");
+    assert_eq!(subprocess_payload["ok"], true);
+    assert_eq!(subprocess_payload["result"]["kind"], "subprocess");
+    assert!(subprocess_payload["result"]["stdout"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("hello"));
+}

--- a/scripts/benchmark-warm-cache-add.sh
+++ b/scripts/benchmark-warm-cache-add.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MYX_BIN="${MYX_BIN:-$ROOT_DIR/target/debug/myx}"
+PACKAGE_SPEC="${PACKAGE_SPEC:-$ROOT_DIR/examples/github-capability}"
+OUT_PATH="${OUT_PATH:-$ROOT_DIR/warm-cache-add.json}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --bin)
+      MYX_BIN="$2"
+      shift 2
+      ;;
+    --package)
+      PACKAGE_SPEC="$2"
+      shift 2
+      ;;
+    --out)
+      OUT_PATH="$2"
+      shift 2
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+timestamp_ms() {
+  local candidate
+  candidate="$(date +%s%3N 2>/dev/null || true)"
+  if [[ "$candidate" =~ ^[0-9]+$ ]]; then
+    echo "$candidate"
+    return
+  fi
+  python3 - <<'PY'
+import time
+print(int(time.time() * 1000))
+PY
+}
+
+measure_add_ms() {
+  local workspace="$1"
+  local start end
+  start="$(timestamp_ms)"
+  (
+    cd "$workspace"
+    MYX_POLICY_MODE=permissive MYX_NON_INTERACTIVE=1 "$MYX_BIN" add "$PACKAGE_SPEC" --json >/dev/null
+  )
+  end="$(timestamp_ms)"
+  echo $((end - start))
+}
+
+if [[ ! -x "$MYX_BIN" ]]; then
+  (cd "$ROOT_DIR" && cargo build -p myx-cli >/dev/null)
+fi
+
+workspace="$(mktemp -d)"
+cleanup() {
+  rm -rf "$workspace"
+}
+trap cleanup EXIT
+
+cold_ms="$(measure_add_ms "$workspace")"
+warm_ms="$(measure_add_ms "$workspace")"
+
+mkdir -p "$(dirname "$OUT_PATH")"
+cat >"$OUT_PATH" <<EOF
+{
+  "benchmark": "warm-cache-myx-add",
+  "package": "$(printf "%s" "$PACKAGE_SPEC")",
+  "workspace": "$(printf "%s" "$workspace")",
+  "cold_ms": $cold_ms,
+  "warm_ms": $warm_ms,
+  "timestamp_utc": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+EOF
+
+echo "warm-cache benchmark report: $OUT_PATH"
+cat "$OUT_PATH"


### PR DESCRIPTION
## Summary
- add deterministic Tier-1 export verification for `openai`, `mcp`, and `skill`
- add MCP runner e2e test that validates healthcheck + HTTP + subprocess invoke paths
- add warm-cache `myx add` benchmark tracking script (non-gating)
- wire benchmark tracking into CI artifact upload and document local invocation

## Why
Issue #18: MVP needed stronger verification harness for determinism, runnable MCP behavior, and benchmark tracking.

## Validation
- cargo fmt --all
- cargo test -p myx-cli
- cargo test -p myx-runtime-executor
- bash scripts/benchmark-warm-cache-add.sh --out ./warm-cache-add.local.json
- bash scripts/check-mvp-contract.sh

Closes #18
