### PR TITLE
Add RFC 0006-0013 MVP spec bundle drafts

### DIFF
--- a/rfcs/0006-mvp-alignment-overview.md
+++ b/rfcs/0006-mvp-alignment-overview.md
@@ -1,0 +1,62 @@
+# RFC 0006: MVP Alignment Overview
+
+*Status: Draft*
+
+## Goal
+
+Define what “all green” MVP alignment means for myx:
+
+- clear spec coverage
+- schema/type contracts where needed
+- deterministic behavior
+- explicit failure modes
+- reference command flow
+
+## MVP Definition
+
+### Platform
+
+- macOS-first
+- Homebrew distribution target
+- Rust-first implementation
+
+### CLI Surface
+
+- `myx init`
+- `myx add <name|path>`
+- `myx inspect <name|path>`
+- `myx build --target <openai|mcp|skill>`
+- `myx run <package>.<tool> [--input json]`
+
+### Tier-1 Targets
+
+- `openai`
+- `mcp`
+- `skill`
+
+### Non-Goals for MVP
+
+- hosted registry
+- external plugin system
+- Tier-2 targets (`vercel`, `claude`, `gemini`)
+- package signing verification as a release gate
+- broad subprocess flexibility
+- daemonized hosted runtime architecture
+
+## Core Principle
+
+myx should execute as a deterministic pipeline:
+
+```text
+resolve -> validate -> inspect policy -> install -> run -> export
+```
+
+## Required Green Areas
+
+- runtime executor
+- policy enforcement
+- run command
+- capability profile enforcement
+- lockfile semantics
+- static index semantics
+- Tier-1 export determinism

--- a/rfcs/0007-runtime-executor-spec.md
+++ b/rfcs/0007-runtime-executor-spec.md
@@ -1,0 +1,135 @@
+# RFC 0007: Runtime Executor Spec
+
+*Status: Draft*
+
+## Purpose
+
+The runtime executor executes capability tools deterministically while enforcing declared permissions.
+
+## Suggested Crate
+
+```text
+crates/myx-runtime
+```
+
+## Responsibilities
+
+- validate execution blocks
+- enforce permissions and policy
+- execute `http` actions
+- execute `subprocess` actions
+- capture output and diagnostics
+- return structured results
+- never invoke a shell implicitly
+
+## Execution Kinds
+
+Supported in MVP:
+
+- `http`
+- `subprocess`
+
+## Rust-Oriented API Sketch
+
+```rust
+pub enum ExecutionRequest {
+    Http(HttpRequest),
+    Subprocess(SubprocessRequest),
+}
+
+pub enum ExecutionStatus {
+    Success,
+    Failed,
+    TimedOut,
+    Denied,
+}
+
+pub struct ExecutionResult {
+    pub status: ExecutionStatus,
+    pub output: Option<String>,
+    pub error: Option<ExecutionError>,
+    pub duration_ms: u64,
+}
+```
+
+## HTTP Execution Spec
+
+### Example
+
+```json
+{
+  "type": "http",
+  "method": "GET",
+  "url": "https://api.github.com/repos/{owner}/{repo}",
+  "headers": {
+    "Authorization": "Bearer {{GITHUB_TOKEN}}"
+  },
+  "timeout_ms": 5000
+}
+```
+
+### Rules
+
+- URL host must match `permissions.network`
+- timeout is required
+- redirects must not escape allowed hosts
+- headers may only resolve declared secrets
+- method must be explicit
+- request body templates must validate before execution
+
+## Subprocess Execution Spec
+
+### Example
+
+```json
+{
+  "type": "subprocess",
+  "command": "git",
+  "args": ["clone", "{{repo}}"],
+  "cwd": "./workspace",
+  "env": {
+    "GIT_TOKEN": "{{GIT_TOKEN}}"
+  },
+  "timeout_ms": 10000
+}
+```
+
+### Rules
+
+- command must match exact allowlist
+- no shell invocation
+- no shell expansion
+- no string command mode
+- cwd must resolve inside allowed path bounds
+- env passthrough must be explicitly allowlisted
+- timeout is required
+- stdout/stderr should be captured deterministically
+
+## Execution Flow
+
+```text
+load tool
+-> validate execution block
+-> resolve templates
+-> enforce policy
+-> execute
+-> capture result
+-> return structured output
+```
+
+## Failure Modes
+
+- `E_EXEC_INVALID`
+- `E_POLICY_DENIED`
+- `E_TIMEOUT`
+- `E_RUNTIME_FAIL`
+- `E_SECRET_MISSING`
+- `E_NETWORK_DENIED`
+- `E_FILESYSTEM_DENIED`
+
+## Determinism Requirements
+
+- same input + same environment policy should produce the same execution plan
+- timeouts should be measured consistently
+- template resolution should be explicit and deterministic
+- failures should map to stable error codes

--- a/rfcs/0008-policy-enforcement-spec.md
+++ b/rfcs/0008-policy-enforcement-spec.md
@@ -1,0 +1,102 @@
+# RFC 0008: Policy Enforcement Spec
+
+*Status: Draft*
+
+## Purpose
+
+Policy enforcement ensures tool execution adheres strictly to declared permissions and explicit operator approval.
+
+Default stance:
+
+- deny by default
+- allow only explicitly declared and approved behavior
+
+## Policy Model
+
+```rust
+pub struct Policy {
+    pub network_hosts: Vec<String>,
+    pub allowed_commands: Vec<String>,
+    pub allowed_env: Vec<String>,
+    pub filesystem_read: Vec<PathBuf>,
+    pub filesystem_write: Vec<PathBuf>,
+}
+```
+
+## Enforcement Domains
+
+### Network
+
+- only declared hosts are allowed
+- matching must be exact (or explicitly pattern-based in future versions)
+- redirects to undeclared hosts must fail
+
+### Subprocess
+
+- exact command allowlist only in MVP
+- no shell
+- no implicit shell wrappers
+- cwd must be within allowed filesystem bounds
+- env keys must be explicitly allowed
+
+### Filesystem
+
+- read bounds and write bounds must be checked separately
+- subprocess actions inherit filesystem constraints
+- path normalization must happen before comparison
+
+## Review Modes
+
+### Interactive Default
+
+When a package is added or first run, the user is shown requested permissions and prompted to approve.
+
+Example:
+
+```text
+This package requests:
+- network: api.github.com
+- subprocess: git
+- filesystem write: ./workspace
+
+Allow? (y/n)
+```
+
+### CI / Non-Interactive
+
+- explicit allowlist required
+- absence of allowlist is a hard failure
+- no prompt fallback
+
+## Failure Contract
+
+### Example JSON
+
+```json
+{
+  "error": "E_POLICY_DENIED",
+  "reason": "command 'bash' not allowed"
+}
+```
+
+## Enforcement Timing
+
+Policy checks happen at:
+
+- install review
+- run-time execution
+- build-time validation when required semantics imply execution capability constraints
+
+## Recommended Exit/Error Categories
+
+- `E_POLICY_DENIED`
+- `E_POLICY_INTERACTIVE_REQUIRED`
+- `E_NETWORK_DENIED`
+- `E_SUBPROCESS_DENIED`
+- `E_FILESYSTEM_DENIED`
+
+## MVP Constraints
+
+- no policy wildcards for subprocess commands
+- no shell-based execution
+- no implicit env inheritance beyond declared passthrough

--- a/rfcs/0009-run-command-spec.md
+++ b/rfcs/0009-run-command-spec.md
@@ -1,0 +1,85 @@
+# RFC 0009: Run Command Spec
+
+*Status: Draft*
+
+## Purpose
+
+`myx run` provides a minimal execution path to prove runtime and policy behavior end-to-end.
+
+## Command
+
+```bash
+myx run <package>.<tool> [--input json]
+```
+
+## Examples
+
+```bash
+myx run github.search_repositories --input '{"query":"rust"}'
+myx run local.echo --input '{"text":"hello"}'
+```
+
+## Flow
+
+```text
+resolve package
+-> load profile
+-> validate tool exists
+-> construct execution request
+-> enforce policy
+-> execute via runtime
+-> return output
+```
+
+## Input Contract
+
+- `--input` accepts a JSON object
+- input must validate against the tool parameter schema
+- invalid input returns deterministic validation error
+
+## Default Human Output
+
+```text
+✓ executed github.search_repositories
+-> 12 results returned
+```
+
+## JSON Output
+
+```json
+{
+  "status": "success",
+  "duration_ms": 120,
+  "output": {
+    "results": 12
+  }
+}
+```
+
+## Error Output
+
+```json
+{
+  "status": "error",
+  "error": "E_TOOL_NOT_FOUND",
+  "message": "Tool 'search_repositories' not found in package 'github'"
+}
+```
+
+## Error Codes
+
+- `E_TOOL_NOT_FOUND`
+- `E_INPUT_INVALID`
+- `E_POLICY_DENIED`
+- `E_EXEC_FAIL`
+- `E_TIMEOUT`
+- `E_SECRET_MISSING`
+
+## MVP Requirement
+
+A valid MVP should support at least:
+
+- one HTTP-based tool path
+- one subprocess-based tool path
+
+through `myx run`.

--- a/rfcs/0010-capability-profile-v1-spec.md
+++ b/rfcs/0010-capability-profile-v1-spec.md
@@ -1,0 +1,100 @@
+# RFC 0010: Capability Profile v1 Spec
+
+*Status: Draft*
+
+## Purpose
+
+Capability Profile v1 is the canonical contract for myx packages and exports.
+
+All Tier-1 targets build from this profile.
+
+## Required Top-Level Fields
+
+- `name`
+- `version`
+- `description`
+- `tools`
+- `permissions`
+
+## Tool Requirements
+
+Each tool must include:
+
+- `name`
+- `description`
+- `tool_class`
+- `parameters`
+- `execution`
+
+## Tool Classes
+
+Required enum:
+
+- `http_api`
+- `local_process`
+- `filesystem_assisted`
+- `composite`
+
+### MVP Note
+
+`composite` may remain reserved or minimally defined if not implemented in MVP.
+
+## Execution Block
+
+Required for every tool.
+
+### HTTP Example
+
+```json
+{
+  "type": "http",
+  "method": "GET",
+  "url": "https://api.github.com/search/repositories?q={{query}}",
+  "headers": {
+    "Authorization": "Bearer {{GITHUB_TOKEN}}"
+  },
+  "timeout_ms": 5000
+}
+```
+
+### Subprocess Example
+
+```json
+{
+  "type": "subprocess",
+  "command": "git",
+  "args": ["status"],
+  "cwd": "./workspace",
+  "env": {},
+  "timeout_ms": 5000
+}
+```
+
+## Permissions
+
+### Required domains
+
+- `network`
+- `subprocess`
+- `filesystem`
+
+### Semantics
+
+- `permissions.network` is a host allowlist
+- `permissions.subprocess` is a structured command allowlist
+- `permissions.filesystem` specifies readable and writable bounds
+
+## Validation Rules
+
+- `tool_class` required
+- `execution` required
+- timeout required
+- permissions required for executable tools
+- invalid or missing execution declarations fail deterministically
+
+## Export Principle
+
+Exports may be lossy, but:
+
+- required mismatches hard-fail
+- lossy conversions emit explicit loss reports

--- a/rfcs/0011-lockfile-spec.md
+++ b/rfcs/0011-lockfile-spec.md
@@ -1,0 +1,55 @@
+# RFC 0011: Lockfile Spec
+
+*Status: Draft*
+
+## File Name
+
+```text
+myx.lock
+```
+
+## Purpose
+
+The lockfile captures deterministic install state.
+
+## Required Data
+
+For each installed package:
+
+- resolved source
+- version
+- digest
+- install-time permission snapshot
+
+## Example
+
+```json
+{
+  "version": 1,
+  "packages": {
+    "github": {
+      "version": "0.1.0",
+      "resolved": "https://index.example/github-0.1.0.tar.gz",
+      "digest": "sha256:abc123",
+      "permissions_snapshot": {
+        "network": ["api.github.com"],
+        "subprocess": ["git"]
+      }
+    }
+  }
+}
+```
+
+## Rules
+
+- deterministic ordering
+- atomic write
+- no mutation on failed install
+- failed `add` leaves previous lockfile unchanged
+- digest must match fetched artifact
+
+## Failure Modes
+
+- `E_LOCK_WRITE`
+- `E_LOCK_ATOMICITY`
+- `E_DIGEST_MISMATCH`

--- a/rfcs/0012-static-index-spec.md
+++ b/rfcs/0012-static-index-spec.md
@@ -1,0 +1,57 @@
+# RFC 0012: Static Index Spec
+
+*Status: Draft*
+
+## Purpose
+
+Static indexes are the package discovery mechanism for MVP.
+
+No hosted registry is required.
+
+## Transport
+
+- local file
+- HTTP JSON document
+
+## Example Schema
+
+```json
+{
+  "packages": {
+    "github": [
+      {
+        "version": "0.1.0",
+        "url": "https://example.com/github-0.1.0.tar.gz",
+        "digest": "sha256:abc123",
+        "description": "GitHub capability package",
+        "capabilities": ["search_repos", "read_issues"]
+      }
+    ]
+  }
+}
+```
+
+## Requirements
+
+- exact version resolution must be deterministic
+- digest is required
+- install source must be explicit
+- precedence rules between indexes must be defined and deterministic
+
+## Resolver Behavior
+
+```text
+load configured indexes
+-> merge by precedence
+-> resolve exact package version
+-> fetch artifact
+-> verify digest
+-> install
+```
+
+## Failure Modes
+
+- `E_RESOLVE`
+- `E_VERSION_NOT_FOUND`
+- `E_INDEX_INVALID`
+- `E_DIGEST_MISMATCH`

--- a/rfcs/0013-mvp-green-checklist.md
+++ b/rfcs/0013-mvp-green-checklist.md
@@ -1,0 +1,58 @@
+# RFC 0013: MVP Green Checklist
+
+*Status: Draft*
+
+## Core Runtime
+
+- [ ] Runtime executor spec implemented
+- [ ] HTTP execution path implemented
+- [ ] Subprocess execution path implemented
+- [ ] No-shell enforcement implemented
+- [ ] Policy enforcement wired into execution
+
+## CLI
+
+- [ ] `myx init`
+- [ ] `myx add`
+- [ ] `myx inspect`
+- [ ] `myx build`
+- [ ] `myx run`
+
+## Contracts
+
+- [ ] Capability Profile v1 enforced
+- [ ] Lockfile deterministic and atomic
+- [ ] Static index schema enforced
+- [ ] Stable error codes implemented
+
+## Tier-1 Targets
+
+- [ ] `openai` export deterministic
+- [ ] `mcp` wrapper generated and runnable
+- [ ] `skill` export deterministic
+- [ ] Loss reports emitted when lossy
+
+## Validation and Tests
+
+- [ ] Schema validation tests
+- [ ] Resolver tests
+- [ ] Policy denial tests
+- [ ] Runtime executor tests
+- [ ] Golden export tests
+- [ ] MCP runnable check
+- [ ] Warm-cache benchmark tracked
+
+## Ship Gate
+
+A release-ready MVP must satisfy:
+
+```text
+add -> inspect -> run -> build
+```
+
+with:
+
+- deterministic behavior
+- policy correctness
+- Tier-1 target support
+- explicit loss reporting


### PR DESCRIPTION
## Summary
- add RFC 0006-0013 as implementation-facing MVP spec drafts imported from the provided spec bundle
- cover: alignment overview, runtime executor, policy enforcement, run command, capability profile v1, lockfile, static index, and MVP green checklist

## Included RFCs
- RFC 0006: MVP Alignment Overview
- RFC 0007: Runtime Executor Spec
- RFC 0008: Policy Enforcement Spec
- RFC 0009: Run Command Spec
- RFC 0010: Capability Profile v1 Spec
- RFC 0011: Lockfile Spec
- RFC 0012: Static Index Spec
- RFC 0013: MVP Green Checklist

## Notes
These are draft RFCs intended as the target-state spec set for follow-on implementation work.
