### PR TITLE
Implement RFC 0009 run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## Status
 
-Early MVP implementation has started as a Rust monorepo. Specs and RFCs remain the source of truth while core crates are scaffolded for `init/add/inspect/build`.
+Early MVP implementation has started as a Rust monorepo. Specs and RFCs remain the source of truth while core crates are scaffolded for `init/add/inspect/build/run`.
 Repository and org mapping guidance lives in `docs/repository-structure.md`.
 
 ## Rust Monorepo Layout

--- a/crates/myx-cli/src/cli.rs
+++ b/crates/myx-cli/src/cli.rs
@@ -50,4 +50,19 @@ pub enum Commands {
         #[arg(long, default_value_t = false)]
         json: bool,
     },
+    Run {
+        target: String,
+        #[arg(long, value_name = "JSON")]
+        input: Option<String>,
+        #[arg(long)]
+        config: Option<PathBuf>,
+        #[arg(
+            long,
+            default_value_t = false,
+            help = "Disable interactive policy prompts"
+        )]
+        non_interactive: bool,
+        #[arg(long, default_value_t = false)]
+        json: bool,
+    },
 }

--- a/crates/myx-cli/src/commands/mod.rs
+++ b/crates/myx-cli/src/commands/mod.rs
@@ -2,8 +2,10 @@ pub mod add;
 pub mod build;
 pub mod init;
 pub mod inspect;
+pub mod run;
 
 pub use add::command_add;
 pub use build::command_build;
 pub use init::command_init;
 pub use inspect::command_inspect;
+pub use run::command_run;

--- a/crates/myx-cli/src/commands/run.rs
+++ b/crates/myx-cli/src/commands/run.rs
@@ -1,0 +1,188 @@
+use std::path::PathBuf;
+use std::time::Instant;
+
+use anyhow::Result;
+use myx_core::load_config;
+use myx_policy::{evaluate_install_policy, Decision};
+use serde_json::{json, Value};
+
+use crate::exit::{fail, CliExit};
+use crate::non_interactive::resolve_non_interactive_mode;
+use crate::util::resolve_bundle;
+
+fn parse_run_target(target: &str) -> Result<(&str, &str), CliExit> {
+    let (package, tool) = target.rsplit_once('.').ok_or_else(|| {
+        fail(
+            2,
+            "invalid run target; expected '<package>.<tool>' (example: github.search_repositories)",
+        )
+    })?;
+    if package.trim().is_empty() || tool.trim().is_empty() {
+        return Err(fail(
+            2,
+            "invalid run target; package and tool must both be non-empty",
+        ));
+    }
+    Ok((package, tool))
+}
+
+fn parse_input_json(input: Option<&str>) -> Result<Value, CliExit> {
+    let value = match input {
+        Some(raw) => serde_json::from_str::<Value>(raw)
+            .map_err(|e| fail(3, format!("invalid --input JSON payload: {e}")))?,
+        None => json!({}),
+    };
+    if !value.is_object() {
+        return Err(fail(3, "--input payload must be a JSON object"));
+    }
+    Ok(value)
+}
+
+fn validate_input_against_schema(schema: &Value, input: &Value) -> Result<(), CliExit> {
+    if !schema.is_object() {
+        return Ok(());
+    }
+    if let Some(schema_type) = schema.get("type").and_then(Value::as_str) {
+        if schema_type != "object" {
+            return Err(fail(
+                3,
+                format!(
+                    "tool schema type '{}' is not supported by run input validator",
+                    schema_type
+                ),
+            ));
+        }
+    }
+    if let Some(required) = schema.get("required").and_then(Value::as_array) {
+        let input_obj = input
+            .as_object()
+            .ok_or_else(|| fail(3, "--input payload must be a JSON object"))?;
+        for key in required.iter().filter_map(Value::as_str) {
+            if !input_obj.contains_key(key) {
+                return Err(fail(
+                    3,
+                    format!("input validation failed: missing required field '{}'", key),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn classify_runtime_error(message: &str) -> i32 {
+    if message.contains("not allowed")
+        || message.contains("outside permissions")
+        || message.contains("permissions.")
+    {
+        return 6;
+    }
+    1
+}
+
+pub fn command_run(
+    target: &str,
+    input: Option<String>,
+    config_override: Option<PathBuf>,
+    non_interactive_flag: bool,
+    json_output: bool,
+) -> Result<(), CliExit> {
+    let cwd = std::env::current_dir().map_err(|e| fail(1, e))?;
+    let config = load_config(config_override.as_deref(), &cwd).map_err(|e| fail(1, e))?;
+    let (package_spec, tool_name) = parse_run_target(target)?;
+    let (_resolved, bundle) =
+        resolve_bundle(package_spec, &config, &cwd).map_err(|e| fail(4, e))?;
+    let non_interactive_mode =
+        resolve_non_interactive_mode(non_interactive_flag).map_err(|e| fail(2, e))?;
+
+    let policy_result = evaluate_install_policy(
+        &config.policy,
+        &bundle.profile.permissions,
+        non_interactive_mode.enabled,
+    )
+    .map_err(|e| fail(1, e))?;
+    if matches!(policy_result.decision, Decision::Deny) {
+        if non_interactive_mode.enabled {
+            return Err(fail(
+                6,
+                format!(
+                    "{} (non-interactive mode: {})",
+                    policy_result.reason, non_interactive_mode.reason
+                ),
+            ));
+        }
+        return Err(fail(6, policy_result.reason));
+    }
+
+    let tool = bundle
+        .profile
+        .tools
+        .iter()
+        .find(|t| t.name == tool_name)
+        .ok_or_else(|| {
+            fail(
+                3,
+                format!(
+                    "tool '{}' not found in package '{}'",
+                    tool_name, bundle.manifest.name
+                ),
+            )
+        })?;
+
+    myx_runtime_executor::validate_execution(&tool.execution).map_err(|e| fail(3, e))?;
+    let input_value = parse_input_json(input.as_deref())?;
+    validate_input_against_schema(&tool.parameters, &input_value)?;
+
+    let start = Instant::now();
+    let result = myx_runtime_executor::execute_tool(
+        tool,
+        &bundle.profile.permissions,
+        &bundle.package_dir,
+        &input_value,
+    )
+    .map_err(|e| {
+        let msg = e.to_string();
+        fail(classify_runtime_error(&msg), msg)
+    })?;
+    let duration_ms = start.elapsed().as_millis() as u64;
+
+    if json_output {
+        let out = json!({
+            "command": "run",
+            "ok": true,
+            "package": {
+                "name": bundle.manifest.name,
+                "version": bundle.manifest.version
+            },
+            "tool": tool.name,
+            "duration_ms": duration_ms,
+            "result": result
+        });
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&out).map_err(|e| fail(1, e))?
+        );
+        return Ok(());
+    }
+
+    println!("executed {}.{}", bundle.manifest.name, tool.name);
+    println!("kind: {}", result.kind);
+    if let Some(status_code) = result.status_code {
+        println!("status_code: {}", status_code);
+    }
+    if let Some(exit_code) = result.exit_code {
+        println!("exit_code: {}", exit_code);
+    }
+    if let Some(stdout) = &result.stdout {
+        if !stdout.trim().is_empty() {
+            println!("stdout:\n{}", stdout);
+        }
+    }
+    if let Some(body) = &result.body {
+        if !body.trim().is_empty() {
+            println!("body:\n{}", body);
+        }
+    }
+    println!("duration_ms: {}", duration_ms);
+
+    Ok(())
+}

--- a/crates/myx-cli/src/main.rs
+++ b/crates/myx-cli/src/main.rs
@@ -34,6 +34,13 @@ fn run(cli: Cli) -> Result<(), CliExit> {
             config,
             json,
         } => commands::command_build(&target, package, config, json),
+        Commands::Run {
+            target,
+            input,
+            config,
+            non_interactive,
+            json,
+        } => commands::command_run(&target, input, config, non_interactive, json),
     }
 }
 

--- a/crates/myx-cli/tests/run_command.rs
+++ b/crates/myx-cli/tests/run_command.rs
@@ -1,0 +1,237 @@
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::{json, Value};
+use tempfile::TempDir;
+
+fn run_myx(args: &[&str], cwd: &Path) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_myx"))
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .expect("run myx")
+}
+
+fn write_package(dir: &Path, name: &str, version: &str, profile: &Value) -> PathBuf {
+    let pkg_dir = dir.join(format!("{name}-{version}"));
+    std::fs::create_dir_all(&pkg_dir).expect("create package dir");
+    std::fs::write(
+        pkg_dir.join("myx.yaml"),
+        format!(
+            "name: {name}\nversion: {version}\ndescription: test\npublisher: test\nlicense: Apache-2.0\nir: ./capability.json\n"
+        ),
+    )
+    .expect("write manifest");
+    std::fs::write(
+        pkg_dir.join("capability.json"),
+        serde_json::to_vec_pretty(profile).expect("serialize profile"),
+    )
+    .expect("write profile");
+    pkg_dir
+}
+
+fn write_workspace_config(workspace: &Path, package_name: &str, version: &str, source: &Path) {
+    let index_path = workspace.join("index.json");
+    std::fs::write(
+        &index_path,
+        serde_json::to_vec_pretty(&json!({
+            "packages": [
+                {
+                    "name": package_name,
+                    "version": version,
+                    "source": source.display().to_string(),
+                    "digest": "sha256:test"
+                }
+            ]
+        }))
+        .expect("serialize index"),
+    )
+    .expect("write index");
+
+    std::fs::write(
+        workspace.join("myx.config.toml"),
+        format!(
+            "[index]\nsources = [\"{}\"]\n\n[policy]\nmode = \"permissive\"\n",
+            index_path.display()
+        ),
+    )
+    .expect("write config");
+}
+
+#[test]
+fn run_executes_http_tool_and_returns_json() {
+    let tmp = TempDir::new().expect("tempdir");
+    let workspace = tmp.path().join("workspace");
+    let packages = tmp.path().join("packages");
+    std::fs::create_dir_all(&workspace).expect("create workspace");
+    std::fs::create_dir_all(&packages).expect("create packages");
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind local listener");
+    let addr = listener.local_addr().expect("addr");
+    let server = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept");
+        let mut buf = [0u8; 2048];
+        let _ = stream.read(&mut buf);
+        let body = "ok-http";
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: text/plain\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        stream
+            .write_all(response.as_bytes())
+            .expect("write response");
+    });
+
+    let profile = json!({
+        "schema_version": "1",
+        "identity": {
+            "name": "github",
+            "version": "0.1.0",
+            "publisher": "example",
+            "license": "Apache-2.0"
+        },
+        "metadata": {"description": "test", "homepage": "", "source": ""},
+        "capabilities": ["test"],
+        "instructions": {"system": "s", "usage": "u"},
+        "tools": [
+            {
+                "name": "http_ping",
+                "description": "http tool",
+                "parameters": {
+                    "type": "object",
+                    "properties": { "query": {"type":"string"} },
+                    "required": ["query"]
+                },
+                "tool_class": "http_api",
+                "execution": {
+                    "kind": "http",
+                    "method": "GET",
+                    "url": format!("http://127.0.0.1:{}/status?q={{{{query}}}}", addr.port()),
+                    "headers": {},
+                    "timeout_ms": 1000
+                }
+            }
+        ],
+        "permissions": {
+            "network": ["127.0.0.1"],
+            "secrets": [],
+            "filesystem": {"read": [], "write": []},
+            "subprocess": {"allowed_commands": [], "allowed_cwds": [], "allowed_env": [], "max_timeout_ms": 10000}
+        },
+        "compatibility": {"runtimes": ["openai","mcp","skill"], "platforms": ["darwin"]}
+    });
+
+    let pkg_dir = write_package(&packages, "github", "0.1.0", &profile);
+    write_workspace_config(&workspace, "github", "0.1.0", &pkg_dir);
+
+    let output = run_myx(
+        &[
+            "run",
+            "github.http_ping",
+            "--input",
+            "{\"query\":\"rust\"}",
+            "--json",
+        ],
+        &workspace,
+    );
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("parse output");
+    assert_eq!(payload["command"], "run");
+    assert_eq!(payload["ok"], true);
+    assert_eq!(payload["tool"], "http_ping");
+    assert_eq!(payload["result"]["kind"], "http");
+    assert_eq!(payload["result"]["status_code"], 200);
+    assert_eq!(payload["result"]["body"], "ok-http");
+
+    server.join().expect("join server");
+}
+
+#[test]
+fn run_executes_subprocess_tool_and_returns_json() {
+    let tmp = TempDir::new().expect("tempdir");
+    let workspace = tmp.path().join("workspace");
+    let packages = tmp.path().join("packages");
+    std::fs::create_dir_all(&workspace).expect("create workspace");
+    std::fs::create_dir_all(&packages).expect("create packages");
+
+    let profile = json!({
+        "schema_version": "1",
+        "identity": {
+            "name": "local",
+            "version": "0.1.0",
+            "publisher": "example",
+            "license": "Apache-2.0"
+        },
+        "metadata": {"description": "test", "homepage": "", "source": ""},
+        "capabilities": ["test"],
+        "instructions": {"system": "s", "usage": "u"},
+        "tools": [
+            {
+                "name": "echo_text",
+                "description": "echo tool",
+                "parameters": {
+                    "type": "object",
+                    "properties": { "text": {"type":"string"} },
+                    "required": ["text"]
+                },
+                "tool_class": "local_process",
+                "execution": {
+                    "kind": "subprocess",
+                    "command": "echo",
+                    "args": ["{{text}}"],
+                    "cwd": ".",
+                    "env_passthrough": ["HOME"],
+                    "timeout_ms": 1000
+                }
+            }
+        ],
+        "permissions": {
+            "network": [],
+            "secrets": [],
+            "filesystem": {"read": ["."], "write": ["."]},
+            "subprocess": {
+                "allowed_commands": ["echo"],
+                "allowed_cwds": ["."],
+                "allowed_env": ["HOME"],
+                "max_timeout_ms": 2000
+            }
+        },
+        "compatibility": {"runtimes": ["mcp"], "platforms": ["darwin"]}
+    });
+
+    let pkg_dir = write_package(&packages, "local", "0.1.0", &profile);
+    write_workspace_config(&workspace, "local", "0.1.0", &pkg_dir);
+
+    let output = run_myx(
+        &[
+            "run",
+            "local.echo_text",
+            "--input",
+            "{\"text\":\"hello\"}",
+            "--json",
+        ],
+        &workspace,
+    );
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("parse output");
+    assert_eq!(payload["command"], "run");
+    assert_eq!(payload["ok"], true);
+    assert_eq!(payload["tool"], "echo_text");
+    assert_eq!(payload["result"]["kind"], "subprocess");
+    assert_eq!(payload["result"]["exit_code"], 0);
+    assert!(payload["result"]["stdout"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("hello"));
+}

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -7,7 +7,8 @@ The MVP (v0) focuses on one deterministic loop:
 1. initialize or obtain a package,
 2. install with explicit policy review,
 3. inspect identity/tools/permissions,
-4. build deterministic target artifacts.
+4. run tools with explicit policy/runtime enforcement,
+5. build deterministic target artifacts.
 
 ## Why myx?
 
@@ -17,7 +18,7 @@ For MVP, the goal is reliability and enforcement, not maximum ecosystem coverage
 
 ## What Ships in MVP
 
-- **Rust core + CLI** with `init`, `add`, `inspect`, `build`.
+- **Rust core + CLI** with `init`, `add`, `inspect`, `build`, `run`.
 - **Capability Profile v1** with explicit `tool_class`, `execution`, and permissions.
 - **Static index + local path resolution** (no hosted registry dependency).
 - **Deterministic lockfile/install semantics** with integrity checks.

--- a/rfcs/0004-cli-contract.md
+++ b/rfcs/0004-cli-contract.md
@@ -7,7 +7,7 @@
 This RFC defines the normative CLI and runtime contract for `myx` MVP (v0):
 
 - Rust core implementation, distributed as a binary (macOS-first via Homebrew).
-- Command surface is limited to `init`, `add`, `inspect`, and `build`.
+- Command surface is limited to `init`, `add`, `inspect`, `build`, and `run`.
 - Export targets are limited to Tier-1: `openai`, `mcp`, `skill`.
 - Package discovery uses local paths and project-configured static indexes.
 - Policy enforcement is mandatory and deterministic.
@@ -21,7 +21,8 @@ MVP must prove one loop with high confidence:
 1. Install package.
 2. Inspect metadata and permissions.
 3. Build deterministic target artifacts.
-4. Run target outputs with explicit security boundaries.
+4. Run tools with explicit security boundaries.
+5. Build deterministic target artifacts.
 
 Scope beyond this loop increases risk without improving the core proof.
 
@@ -29,7 +30,7 @@ Scope beyond this loop increases risk without improving the core proof.
 
 ### In Scope
 
-- Commands: `myx init`, `myx add`, `myx inspect`, `myx build`.
+- Commands: `myx init`, `myx add`, `myx inspect`, `myx build`, `myx run`.
 - Targets: `openai`, `mcp`, `skill`.
 - Sources: local package path and static index package resolution.
 - Runtime execution model: global runtime executor with declarative `http` and `subprocess` tool actions.
@@ -105,10 +106,27 @@ Rules:
 - Repeated builds with unchanged inputs must produce byte-stable outputs.
 - Export must not mutate package source files.
 
-MCP wrapper protocol modes:
-- Wrapper must support strict MCP framing mode (`--protocol mcp`) using `Content-Length` framed JSON-RPC messages over stdio.
-- Wrapper may also support a simplified line-delimited mode (`--protocol simple`) for local debugging.
+MCP runtime bridge protocol modes:
+- Bridge must support strict MCP framing mode (`--protocol mcp`) using `Content-Length` framed JSON-RPC messages over stdio.
+- Bridge may also support a simplified line-delimited mode (`--protocol simple`) for local debugging.
 - Generated MCP launch artifacts must invoke strict MCP mode explicitly.
+
+### `myx run <package>.<tool>`
+
+Purpose:
+- Execute a tool via the runtime executor with policy enforcement.
+
+Behavior:
+1. Resolve package by name using configured static indexes.
+2. Load and validate profile.
+3. Resolve tool by exact name.
+4. Parse `--input` JSON object (default `{}`).
+5. Evaluate policy and run execution via runtime executor.
+
+Rules:
+- Input must be valid JSON object and satisfy required schema fields.
+- Runtime execution must enforce declared permissions.
+- `--json` output includes command status, duration, and structured execution result.
 
 ## Capability Profile v1 Requirements
 

--- a/scripts/check-mvp-contract.sh
+++ b/scripts/check-mvp-contract.sh
@@ -45,7 +45,7 @@ require_pattern \
 
 require_pattern \
   "rfcs/0004-cli-contract.md" \
-  'Command surface is limited to `init`, `add`, `inspect`, and `build`\.' \
+  'Command surface is limited to `init`, `add`, `inspect`, `build`, and `run`\.' \
   "RFC 0004 must define MVP command surface"
 
 require_pattern \


### PR DESCRIPTION
## Summary
- add `myx run <package>.<tool>` command to CLI surface
- support `--input <json>` and `--json` output for run execution
- wire run through resolver + profile validation + policy evaluation + runtime executor
- add integration coverage for both required run paths (HTTP + subprocess)
- update MVP contract/docs and contract-check script to include `run` in command surface

## Behavior
- target format: `package.tool`
- package resolved via configured static indexes
- tool matched by exact name in profile
- input must be a JSON object; required fields are validated from tool schema
- runtime execution output includes structured result and duration

## Validation
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- bash scripts/check-mvp-contract.sh
