### PR TITLE
MVP: disallow subprocess wildcard permissions

### DIFF
--- a/crates/myx-core/src/lib.rs
+++ b/crates/myx-core/src/lib.rs
@@ -230,6 +230,10 @@ fn merge_strings(target: &mut Vec<String>, incoming: Vec<String>) {
     }
 }
 
+fn contains_wildcard(values: &[String]) -> bool {
+    values.iter().any(|v| v == "*")
+}
+
 fn merge_config(base: &mut MyxConfig, incoming: MyxConfig) {
     merge_strings(&mut base.index.sources, incoming.index.sources);
 
@@ -419,6 +423,21 @@ pub fn validate_package(manifest: &PackageManifest, profile: &CapabilityProfile)
                         "subprocess tools require permissions.subprocess.max_timeout_ms"
                     ));
                 }
+                if contains_wildcard(&profile.permissions.subprocess.allowed_commands) {
+                    return Err(anyhow!(
+                        "subprocess permissions must use exact command allowlists; wildcard '*' is not allowed in permissions.subprocess.allowed_commands"
+                    ));
+                }
+                if contains_wildcard(&profile.permissions.subprocess.allowed_cwds) {
+                    return Err(anyhow!(
+                        "subprocess permissions must use exact cwd allowlists; wildcard '*' is not allowed in permissions.subprocess.allowed_cwds"
+                    ));
+                }
+                if contains_wildcard(&profile.permissions.subprocess.allowed_env) {
+                    return Err(anyhow!(
+                        "subprocess permissions must use exact env allowlists; wildcard '*' is not allowed in permissions.subprocess.allowed_env"
+                    ));
+                }
                 if profile.permissions.filesystem.read.is_empty()
                     && profile.permissions.filesystem.write.is_empty()
                 {
@@ -519,5 +538,16 @@ mod tests {
         let mut profile = subprocess_profile();
         profile.permissions.filesystem.read = vec![".".to_string()];
         validate_package(&manifest, &profile).expect("profile should validate");
+    }
+
+    #[test]
+    fn subprocess_tools_reject_wildcard_subprocess_permissions() {
+        let manifest = subprocess_manifest();
+        let mut profile = subprocess_profile();
+        profile.permissions.filesystem.read = vec![".".to_string()];
+        profile.permissions.subprocess.allowed_commands = vec!["*".to_string()];
+        let err =
+            validate_package(&manifest, &profile).expect_err("expected subprocess wildcard error");
+        assert!(err.to_string().contains("exact command allowlists"));
     }
 }

--- a/crates/myx-policy/src/lib.rs
+++ b/crates/myx-policy/src/lib.rs
@@ -27,6 +27,37 @@ fn find_missing(allowed: &[String], requested: &[String]) -> Vec<String> {
         .collect()
 }
 
+fn find_missing_exact(allowed: &[String], requested: &[String]) -> Vec<String> {
+    requested
+        .iter()
+        .filter(|r| !allowed.contains(r))
+        .cloned()
+        .collect()
+}
+
+fn contains_wildcard(values: &[String]) -> bool {
+    values.iter().any(|v| v == "*")
+}
+
+fn validate_subprocess_policy_allowlists(policy: &PolicyConfig) -> Result<()> {
+    if contains_wildcard(&policy.allow_subprocess_commands) {
+        anyhow::bail!(
+            "policy.allow_subprocess_commands must use exact allowlist entries; wildcard '*' is not allowed in MVP"
+        );
+    }
+    if contains_wildcard(&policy.allow_subprocess_cwds) {
+        anyhow::bail!(
+            "policy.allow_subprocess_cwds must use exact allowlist entries; wildcard '*' is not allowed in MVP"
+        );
+    }
+    if contains_wildcard(&policy.allow_subprocess_env) {
+        anyhow::bail!(
+            "policy.allow_subprocess_env must use exact allowlist entries; wildcard '*' is not allowed in MVP"
+        );
+    }
+    Ok(())
+}
+
 fn missing_permissions(policy: &PolicyConfig, permissions: &Permissions) -> Vec<String> {
     let mut missing = Vec::new();
 
@@ -51,13 +82,13 @@ fn missing_permissions(policy: &PolicyConfig, permissions: &Permissions) -> Vec<
     ) {
         missing.push(format!("subprocess_command:{item}"));
     }
-    for item in find_missing(
+    for item in find_missing_exact(
         &policy.allow_subprocess_cwds,
         &permissions.subprocess.allowed_cwds,
     ) {
         missing.push(format!("subprocess_cwd:{item}"));
     }
-    for item in find_missing(
+    for item in find_missing_exact(
         &policy.allow_subprocess_env,
         &permissions.subprocess.allowed_env,
     ) {
@@ -86,6 +117,8 @@ pub fn evaluate_install_policy(
     permissions: &Permissions,
     non_interactive: bool,
 ) -> Result<PolicyResult> {
+    validate_subprocess_policy_allowlists(policy)?;
+
     if matches!(policy.mode, PolicyMode::Permissive) {
         return Ok(PolicyResult {
             decision: Decision::Allow,
@@ -208,5 +241,19 @@ mod tests {
             evaluate_install_policy(&policy, &sample_permissions(), true).expect("policy eval");
         assert!(matches!(result.decision, Decision::Deny));
         assert!(result.reason.contains("non-interactive mode"));
+    }
+
+    #[test]
+    fn rejects_wildcard_subprocess_allowlist_entries() {
+        let policy = PolicyConfig {
+            mode: PolicyMode::ReviewRequired,
+            allow_subprocess_commands: vec!["*".to_string()],
+            ..PolicyConfig::default()
+        };
+        let err = evaluate_install_policy(&policy, &sample_permissions(), true)
+            .expect_err("expected wildcard subprocess policy rejection");
+        assert!(err
+            .to_string()
+            .contains("allow_subprocess_commands must use exact allowlist entries"));
     }
 }

--- a/crates/myx-runtime-executor/src/lib.rs
+++ b/crates/myx-runtime-executor/src/lib.rs
@@ -141,6 +141,8 @@ fn validate_tool_permissions(
     permissions: &Permissions,
     base_dir: &Path,
 ) -> Result<()> {
+    validate_subprocess_allowlists(permissions)?;
+
     match &tool.execution {
         ToolExecution::Http { url, .. } => {
             let host = extract_host_from_template(url).with_context(|| {
@@ -164,7 +166,7 @@ fn validate_tool_permissions(
             timeout_ms,
             ..
         } => {
-            if !contains_or_wildcard(&permissions.subprocess.allowed_commands, command) {
+            if !contains_exact(&permissions.subprocess.allowed_commands, command) {
                 anyhow::bail!(
                     "tool '{}' command '{}' is not in permissions.subprocess.allowed_commands",
                     tool.name,
@@ -193,7 +195,7 @@ fn validate_tool_permissions(
             }
 
             for env_key in env_passthrough {
-                if !contains_or_wildcard(&permissions.subprocess.allowed_env, env_key) {
+                if !contains_exact(&permissions.subprocess.allowed_env, env_key) {
                     anyhow::bail!(
                         "tool '{}' env '{}' is not in permissions.subprocess.allowed_env",
                         tool.name,
@@ -345,7 +347,7 @@ fn execute_subprocess(
     base_dir: &Path,
     args: &Map<String, Value>,
 ) -> Result<ExecutionOutput> {
-    if !contains_or_wildcard(&permissions.subprocess.allowed_commands, command) {
+    if !contains_exact(&permissions.subprocess.allowed_commands, command) {
         anyhow::bail!(
             "subprocess command '{}' not allowed by permissions.subprocess.allowed_commands",
             command
@@ -371,7 +373,7 @@ fn execute_subprocess(
     }
 
     for env_key in env_passthrough {
-        if !contains_or_wildcard(&permissions.subprocess.allowed_env, env_key) {
+        if !contains_exact(&permissions.subprocess.allowed_env, env_key) {
             anyhow::bail!(
                 "subprocess env '{}' not allowed by permissions.subprocess.allowed_env",
                 env_key
@@ -492,6 +494,33 @@ fn contains_or_wildcard(allowed: &[String], value: &str) -> bool {
     allowed.iter().any(|a| a == "*" || a == value)
 }
 
+fn contains_exact(allowed: &[String], value: &str) -> bool {
+    allowed.iter().any(|a| a == value)
+}
+
+fn contains_wildcard(allowed: &[String]) -> bool {
+    allowed.iter().any(|a| a == "*")
+}
+
+fn validate_subprocess_allowlists(permissions: &Permissions) -> Result<()> {
+    if contains_wildcard(&permissions.subprocess.allowed_commands) {
+        anyhow::bail!(
+            "permissions.subprocess.allowed_commands must use exact entries; wildcard '*' is not allowed in MVP"
+        );
+    }
+    if contains_wildcard(&permissions.subprocess.allowed_cwds) {
+        anyhow::bail!(
+            "permissions.subprocess.allowed_cwds must use exact entries; wildcard '*' is not allowed in MVP"
+        );
+    }
+    if contains_wildcard(&permissions.subprocess.allowed_env) {
+        anyhow::bail!(
+            "permissions.subprocess.allowed_env must use exact entries; wildcard '*' is not allowed in MVP"
+        );
+    }
+    Ok(())
+}
+
 fn extract_host_from_template(url_template: &str) -> Result<String> {
     let parsed = match url::Url::parse(url_template) {
         Ok(url) => url,
@@ -543,9 +572,6 @@ fn resolve_cwd(base_dir: &Path, cwd: Option<&str>) -> PathBuf {
 }
 
 fn cwd_is_allowed(base_dir: &Path, requested: &Path, allowed_cwds: &[String]) -> bool {
-    if allowed_cwds.iter().any(|a| a == "*") {
-        return true;
-    }
     let requested_norm = normalize_path(requested);
     allowed_cwds.iter().any(|entry| {
         let allow_path = resolve_cwd(base_dir, Some(entry));
@@ -667,6 +693,22 @@ mod tests {
         )
         .expect_err("expected filesystem bounds failure");
         assert!(err.to_string().contains("filesystem bounds"));
+    }
+
+    #[test]
+    fn subprocess_rejects_wildcard_command_allowlist() {
+        let tmp = TempDir::new().expect("tempdir");
+        let mut permissions = test_permissions();
+        permissions.subprocess.allowed_commands = vec!["*".to_string()];
+
+        let err = execute_tool(
+            &subprocess_tool(),
+            &permissions,
+            tmp.path(),
+            &serde_json::json!({"message":"hello"}),
+        )
+        .expect_err("expected wildcard deny");
+        assert!(err.to_string().contains("exact entries"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- enforce MVP exact subprocess allowlists by rejecting `*` wildcard entries
- apply enforcement across package validation, policy evaluation, and runtime executor checks
- add regression tests for wildcard rejection paths

## Changes
- `myx-core`: reject wildcard entries in `permissions.subprocess.allowed_commands|allowed_cwds|allowed_env` during package validation
- `myx-policy`: reject wildcard subprocess policy allowlists before install policy evaluation
- `myx-runtime-executor`: require exact matches for subprocess command/cwd/env; reject wildcard subprocess permissions in runtime config/tool validation

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `bash scripts/check-mvp-contract.sh`

Closes #24
