### PR TITLE
add release workflow and homebrew handoff tooling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,130 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version without v prefix (for dry-run packaging)"
+        required: true
+        type: string
+
+jobs:
+  build-macos:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-apple-darwin
+            runner: macos-13
+          - target: aarch64-apple-darwin
+            runner: macos-14
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve release metadata
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
+            tag="${GITHUB_REF_NAME}"
+            version="${tag#v}"
+          else
+            version="${{ github.event.inputs.version }}"
+            version="${version#v}"
+            tag="v${version}"
+          fi
+          echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Build release binaries
+        run: cargo build --locked --release --target "${{ matrix.target }}" -p myx-cli -p myx-runtime-executor
+
+      - name: Package release artifact
+        run: |
+          ./scripts/release/package-dist.sh \
+            --target "${{ matrix.target }}" \
+            --version "${{ steps.meta.outputs.version }}" \
+            --out-dir "$RUNNER_TEMP/dist"
+
+      - name: Upload target artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: myx-${{ steps.meta.outputs.version }}-${{ matrix.target }}
+          path: |
+            ${{ runner.temp }}/dist/*.tar.gz
+            ${{ runner.temp }}/dist/*.tar.gz.sha256
+
+  publish:
+    if: github.event_name == 'push'
+    needs: build-macos
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve release metadata
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          version="${tag#v}"
+          echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+
+      - name: Download packaged artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Create consolidated checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          find dist -type f -name '*.tar.gz' -print0 | sort -z | xargs -0 sha256sum > dist/SHA256SUMS
+
+      - name: Generate Homebrew formula handoff
+        shell: bash
+        run: |
+          set -euo pipefail
+          arm_sha="$(awk '/aarch64-apple-darwin.tar.gz$/ {print $1}' dist/SHA256SUMS)"
+          amd_sha="$(awk '/x86_64-apple-darwin.tar.gz$/ {print $1}' dist/SHA256SUMS)"
+          if [[ -z "${arm_sha}" || -z "${amd_sha}" ]]; then
+            echo "missing expected macOS archive checksums" >&2
+            exit 1
+          fi
+          ./scripts/release/render-homebrew-formula.sh \
+            --version "${{ steps.meta.outputs.version }}" \
+            --repo "${{ github.repository }}" \
+            --darwin-arm64-sha "${arm_sha}" \
+            --darwin-amd64-sha "${amd_sha}" > dist/homebrew-myx.rb
+
+      - name: Upload release metadata artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-metadata-${{ steps.meta.outputs.version }}
+          path: |
+            dist/SHA256SUMS
+            dist/homebrew-myx.rb
+
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.meta.outputs.tag }}
+          name: myx ${{ steps.meta.outputs.tag }}
+          files: |
+            dist/*.tar.gz
+            dist/*.tar.gz.sha256
+            dist/SHA256SUMS
+            dist/homebrew-myx.rb

--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ cargo run -p myx-cli -- build --target mcp
 ./.myx/mcp/run.sh --healthcheck
 ```
 
+## Install (Homebrew)
+
+After tagged releases are published:
+
+```bash
+brew tap myx-hq/myx
+brew install myx
+```
+
+See `docs/release.md` for the release pipeline and Homebrew formula handoff process.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development rules, required checks, and PR expectations.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,63 @@
+# Release Guide
+
+This document defines the MVP release process for `myx` from this repository.
+
+## Scope
+
+- Build and publish macOS binaries (`aarch64-apple-darwin`, `x86_64-apple-darwin`).
+- Publish GitHub release artifacts from a `v*` tag.
+- Generate Homebrew formula handoff content for `myx-hq/homebrew-myx`.
+
+## Pre-Release Checklist
+
+Run from `main` with a clean working tree:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+./scripts/check-mvp-contract.sh
+./scripts/smoke-mvp-loop.sh
+./scripts/benchmark-warm-cache-add.sh --out /tmp/warm-cache-add.json
+```
+
+Confirm MVP contract and RFCs remain aligned before tagging.
+
+## Cut a Release
+
+1. Pick version `X.Y.Z` (matches workspace version semantics).
+2. Create and push tag:
+
+```bash
+git checkout main
+git pull --ff-only
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+3. Tag push triggers `.github/workflows/release.yml`, which:
+- builds release binaries for both macOS targets
+- creates `myx-<version>-<target>.tar.gz` artifacts
+- emits per-archive and consolidated SHA256 files
+- publishes a GitHub release with all artifacts
+- generates `homebrew-myx.rb` handoff artifact
+
+## Homebrew Tap Update
+
+`myx-hq/myx` does not own the tap formula repository. After release completes:
+
+1. Download `homebrew-myx.rb` from release artifacts.
+2. Open PR in `myx-hq/homebrew-myx` updating `Formula/myx.rb`.
+3. Merge formula PR.
+4. Verify install:
+
+```bash
+brew update
+brew tap myx-hq/myx
+brew install myx
+myx --help
+```
+
+## Dry-Run Packaging
+
+Use manual workflow dispatch (`Release`) with a `version` input to validate packaging logic without creating a GitHub release.

--- a/scripts/release/package-dist.sh
+++ b/scripts/release/package-dist.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+usage() {
+  cat <<'EOF'
+Usage: package-dist.sh --target <target-triple> --version <version> [--out-dir <dir>]
+
+Packages release binaries into:
+  myx-<version>-<target-triple>.tar.gz
+  myx-<version>-<target-triple>.tar.gz.sha256
+
+Required:
+  --target   Rust target triple (e.g. aarch64-apple-darwin)
+  --version  Release version without v prefix (e.g. 0.1.0)
+
+Optional:
+  --out-dir  Output directory (default: <repo>/dist)
+EOF
+}
+
+target=""
+version=""
+out_dir="${ROOT_DIR}/dist"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target)
+      target="${2:-}"
+      shift 2
+      ;;
+    --version)
+      version="${2:-}"
+      shift 2
+      ;;
+    --out-dir)
+      out_dir="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "${target}" || -z "${version}" ]]; then
+  echo "error: --target and --version are required" >&2
+  usage
+  exit 2
+fi
+
+version="${version#v}"
+
+bin_dir="${ROOT_DIR}/target/${target}/release"
+for bin in myx myx-mcp-runner; do
+  if [[ ! -x "${bin_dir}/${bin}" ]]; then
+    echo "missing expected binary: ${bin_dir}/${bin}" >&2
+    exit 1
+  fi
+done
+
+mkdir -p "${out_dir}"
+
+archive_base="myx-${version}-${target}"
+archive_path="${out_dir}/${archive_base}.tar.gz"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+staging_dir="${tmp_dir}/${archive_base}"
+mkdir -p "${staging_dir}/bin"
+cp "${bin_dir}/myx" "${staging_dir}/bin/myx"
+cp "${bin_dir}/myx-mcp-runner" "${staging_dir}/bin/myx-mcp-runner"
+cp "${ROOT_DIR}/README.md" "${staging_dir}/README.md"
+cp "${ROOT_DIR}/LICENSE" "${staging_dir}/LICENSE"
+
+tar -C "${tmp_dir}" -czf "${archive_path}" "${archive_base}"
+sha256="$(shasum -a 256 "${archive_path}" | awk '{print $1}')"
+printf '%s  %s\n' "${sha256}" "$(basename "${archive_path}")" > "${archive_path}.sha256"
+
+echo "wrote ${archive_path}"
+echo "wrote ${archive_path}.sha256"

--- a/scripts/release/render-homebrew-formula.sh
+++ b/scripts/release/render-homebrew-formula.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: render-homebrew-formula.sh \
+  --version <version> \
+  --darwin-arm64-sha <sha256> \
+  --darwin-amd64-sha <sha256> \
+  [--repo <owner/repo>]
+
+Renders a Formula/myx.rb file to stdout.
+EOF
+}
+
+version=""
+repo="myx-hq/myx"
+darwin_arm64_sha=""
+darwin_amd64_sha=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)
+      version="${2:-}"
+      shift 2
+      ;;
+    --repo)
+      repo="${2:-}"
+      shift 2
+      ;;
+    --darwin-arm64-sha)
+      darwin_arm64_sha="${2:-}"
+      shift 2
+      ;;
+    --darwin-amd64-sha)
+      darwin_amd64_sha="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "${version}" || -z "${darwin_arm64_sha}" || -z "${darwin_amd64_sha}" ]]; then
+  echo "error: --version, --darwin-arm64-sha, and --darwin-amd64-sha are required" >&2
+  usage
+  exit 2
+fi
+
+version="${version#v}"
+tag="v${version}"
+
+cat <<EOF
+class Myx < Formula
+  desc "Package manager and compatibility layer for agent capabilities"
+  homepage "https://github.com/${repo}"
+  version "${version}"
+  license "Apache-2.0"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "https://github.com/${repo}/releases/download/${tag}/myx-${version}-aarch64-apple-darwin.tar.gz"
+      sha256 "${darwin_arm64_sha}"
+    else
+      url "https://github.com/${repo}/releases/download/${tag}/myx-${version}-x86_64-apple-darwin.tar.gz"
+      sha256 "${darwin_amd64_sha}"
+    end
+  end
+
+  def install
+    bin.install "bin/myx"
+    bin.install "bin/myx-mcp-runner"
+  end
+
+  test do
+    assert_match "myx", shell_output("#{bin}/myx --help")
+  end
+end
+EOF


### PR DESCRIPTION
## Summary
- add a tag-driven release workflow for macOS artifacts
- add release packaging script for myx and myx-mcp-runner tarballs + checksums
- add Homebrew formula renderer and release playbook docs
- document Homebrew install path in README

## Validation
- ./scripts/check-mvp-contract.sh
- cargo test --workspace
- ./scripts/release/package-dist.sh --help
- ./scripts/release/render-homebrew-formula.sh --help
- local package smoke: build + package-dist + formula render